### PR TITLE
chore: add standard automation workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,70 +1,13 @@
-# Dependabot config — closes P2-17 from MONOREPO_REVIEW_2026-04-29.md.
-# Keeps npm + GitHub Actions dependencies up to date with weekly PRs.
-
 version: 2
 updates:
-  # Root + workspaces (npm)
-  - package-ecosystem: npm
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
-      timezone: Asia/Seoul
-    open-pull-requests-limit: 10
-    versioning-strategy: increase
-    commit-message:
-      prefix: 'chore(deps)'
-      include: scope
+      interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
-      - dependencies
-      - npm
-    groups:
-      # Group dev tooling so we don't get N PRs per release of the same family
-      jest:
-        patterns:
-          - 'jest'
-          - '@types/jest'
-          - 'jest-*'
-          - '@jest/*'
-      eslint:
-        patterns:
-          - 'eslint'
-          - 'eslint-*'
-          - '@eslint/*'
-      typescript:
-        patterns:
-          - 'typescript'
-          - '@types/node'
-      cloudflare:
-        patterns:
-          - 'wrangler'
-          - '@cloudflare/*'
-          - 'miniflare'
-      fastify:
-        patterns:
-          - 'fastify'
-          - '@fastify/*'
-    ignore:
-      # rebrowser-puppeteer is intentionally aliased to puppeteer for stealth.
-      # Manual review required before bumping (P2-14).
-      - dependency-name: 'puppeteer'
-        update-types: [version-update:semver-major]
-      # Pin major versions of API contract clients
-      - dependency-name: 'zod'
-        update-types: [version-update:semver-major]
-
-  # GitHub Actions
-  - package-ecosystem: github-actions
-    directory: '/'
-    schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
-      timezone: Asia/Seoul
+      - "dependencies"
+      - "github-actions"
     commit-message:
-      prefix: 'chore(ci)'
-      include: scope
-    labels:
-      - dependencies
-      - github-actions
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,56 @@
+name: Dependabot Auto-Merge
+
+# Auto-approves and merges Dependabot PRs after CI passes.
+# Triggers on PR events from dependabot[bot] only.
+#
+# Merge policy (conservative):
+#   - patch + minor updates  → auto-merge (squash)
+#   - major updates          → auto-approve only (manual merge)
+#   - github-actions ecosystem  → auto-merge regardless of bump (low blast radius)
+#
+# Required setup on each repo:
+#   - allow_auto_merge=true (Public repos: free; Private: Pro/Team only)
+#   - branch protection rule on default branch with status checks (so auto-merge waits for them)
+#
+# If branch protection isn't set, GitHub merges immediately on enable, which is OK
+# because the workflow checks `pull_request` (not `pull_request_target`) and runs on the PR head.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved: ${{ steps.meta.outputs.dependency-names }} ${{ steps.meta.outputs.update-type }}"
+
+      - name: Enable auto-merge for safe updates
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Comment on major update
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr comment "$PR_URL" --body "Major version bump for ${{ steps.meta.outputs.dependency-names }} — manual review required."

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Check out PR head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'requirements.txt') }}

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check Markdown links
         uses: lycheeverse/lychee-action@v1
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -72,7 +72,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -128,7 +128,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Auto-label new issues
         uses: actions/github-script@v7

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -113,7 +113,7 @@ jobs:
     name: Check Large Files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
     name: Check Sensitive Files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### **User description**
## Summary
- add standardized automation workflows from github-bot
- includes PR checks, issue management, and docs sync
- targets the self-hosted homelab runner configuration


___

### **PR Type**
Enhancement


___

### **Description**
- Add Dependabot auto-merge workflow with tiered policy

- Simplify Dependabot config to GitHub Actions only

- Bump `actions/checkout` to v6 across reusable workflows

- Bump `actions/cache` to v5 in PR review workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot PR"] --> B{"Auto-Merge Workflow"}
  B -- "patch / minor / actions" --> C["Auto-Approve + Squash Merge"]
  B -- "major (non-actions)" --> D["Comment: Manual Review"]
  E["Reusable Workflows"] -- "bump" --> F["actions/checkout@v6"]
  G["PR Review Workflow"] -- "bump" --> H["actions/cache@v5"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Simplify Dependabot config to GitHub Actions only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Removed npm ecosystem, dependency groups, and ignore rules<br> <li> Retained GitHub Actions ecosystem with simplified schedule<br> <li> Reduced <code>open-pull-requests-limit</code> from 10 to 5<br> <li> Updated commit-message prefix to <code>chore</code> and scoped labels</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+8/-65</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Add Dependabot auto-merge workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

<ul><li>New workflow to auto-approve and merge Dependabot PRs<br> <li> Auto-merges patch, minor, and <code>github_actions</code> updates via squash<br> <li> Comments on major version bumps requiring manual review<br> <li> Filters trigger to <code>dependabot[bot]</code> and non-draft PRs only</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review.yml</strong><dd><code>Bump checkout and cache action versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review.yml

<ul><li>Upgraded <code>actions/checkout</code> from v4 to v6<br> <li> Upgraded <code>actions/cache</code> from v4 to v5</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-docs-sync.yml</strong><dd><code>Bump checkout action to v6 in docs sync workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-docs-sync.yml

<ul><li>Upgraded <code>actions/checkout</code> from v4 to v6 in four jobs<br> <li> Affected <code>link-check</code>, <code>markdown-lint</code>, <code>readme-sync-check</code>, and <br><code>api-docs-check</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-4a1f29f72a980db95bc8265ef1c75404098d95a138d2c59772083ec5259c4d2a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-issue-management.yml</strong><dd><code>Bump checkout action to v6 in issue management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-issue-management.yml

- Upgraded `actions/checkout` from v4 to v6 in the `auto-label` job


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-321d5a584f7c9be882556476d570355f5243ec98cb2925e63566ada047783335">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>Bump checkout action to v6 in PR checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li>Upgraded <code>actions/checkout</code> from v4 to v6 in <code>check-large-files</code> job<br> <li> Upgraded <code>actions/checkout</code> from v4 to v6 in <code>check-sensitive-files</code> job</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/76/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

