### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,19 +1,19 @@
 name: Dependabot Auto-Merge
 
-# Auto-approves and merges Dependabot PRs after CI passes.
-# Triggers on PR events from dependabot[bot] only.
+# Auto-approves and enables auto-merge for Dependabot PRs.
+# Auto-merge waits for required status checks (configured via branch protection)
+# before actually merging.
 #
 # Merge policy (conservative):
-#   - patch + minor updates  → auto-merge (squash)
-#   - major updates          → auto-approve only (manual merge)
-#   - github-actions ecosystem  → auto-merge regardless of bump (low blast radius)
+#   - patch + minor updates  -> auto-merge (squash)
+#   - github_actions ecosystem -> auto-merge regardless of bump (low blast radius)
+#   - major updates outside github_actions -> comment, manual review
+#   - unknown update-type    -> comment, manual review (e.g. pip metadata gaps)
 #
 # Required setup on each repo:
 #   - allow_auto_merge=true (Public repos: free; Private: Pro/Team only)
-#   - branch protection rule on default branch with status checks (so auto-merge waits for them)
-#
-# If branch protection isn't set, GitHub merges immediately on enable, which is OK
-# because the workflow checks `pull_request` (not `pull_request_target`) and runs on the PR head.
+#   - branch protection rule on default branch with required status checks
+#     (so auto-merge actually waits for CI before merging)
 
 on:
   pull_request:
@@ -34,12 +34,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve PR
+      - name: Approve safe updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr review --approve "$PR_URL" --body "Auto-approved: ${{ steps.meta.outputs.dependency-names }} ${{ steps.meta.outputs.update-type }}"
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)"
 
       - name: Enable auto-merge for safe updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
@@ -48,9 +50,19 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 
-      - name: Comment on major update
+      - name: Flag major updates for manual review
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr comment "$PR_URL" --body "Major version bump for ${{ steps.meta.outputs.dependency-names }} — manual review required."
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: gh pr comment "$PR_URL" --body "Major version bump for $DEP_NAMES - manual review required."
+
+      - name: Flag unknown update type for manual review
+        if: ${{ steps.meta.outputs.update-type == '' || steps.meta.outputs.update-type == 'null' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: gh pr comment "$PR_URL" --body "Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required."

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,7 +11,11 @@ permissions:
 
 jobs:
   pr_review:
-    if: github.event.pull_request.user.login == 'jclee941'
+    # Run for all PRs except draft and dependabot[bot] (dependency bumps
+    # are handled by dependabot-auto-merge.yml). Bots/forks are still
+    # reviewed because GITHUB_TOKEN has read-only on cross-repo PRs and
+    # the workflow doesn't expose secrets to PR code.
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: PR review via CLIProxyAPI
     timeout-minutes: 15


### PR DESCRIPTION
### **User description**
## Summary
- sync standard automation workflows from jclee941/.github
- includes PR checks, issue management, docs sync, dependabot auto-merge
- adds .github/dependabot.yml for weekly github-actions updates
- targets the self-hosted homelab runner configuration


___

### **PR Type**
Enhancement


___

### **Description**
- Broaden PR review workflow trigger conditions

- Add unknown update-type handling for Dependabot

- Improve workflow documentation and step clarity

- Extract metadata into environment variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR opened"] --> B{"Author"}
  B -->|"dependabot[bot]"| C["dependabot-auto-merge.yml"]
  B -->|"other user"| D["pr-review.yml"]
  C -->|"safe update"| E["Auto-approve & merge"]
  C -->|"unknown type"| F["Flag manual review"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Refine dependabot auto-merge policies and edge-case handling</code></dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

<ul><li>Add step to flag empty or null <code>update-type</code> values for manual review<br> <li> Rename steps for clarity and extract metadata into environment <br>variables<br> <li> Update header comments to clarify branch protection requirements and <br>merge policy</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/77/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+25/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-review.yml</strong><dd><code>Broaden PR review workflow trigger conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review.yml

<ul><li>Replace user-specific trigger (<code>jclee941</code>) with universal non-draft, <br>non-<code>dependabot[bot]</code> condition<br> <li> Add explanatory comments for dependabot exclusion and fork safety</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/77/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

