### PR TITLE
docs(sisyphus): evidence for PDF CTA, portfolio QA, Workers Builds infra

### DIFF
--- a/.sisyphus/evidence/portfolio-improvements-manual-qa.md
+++ b/.sisyphus/evidence/portfolio-improvements-manual-qa.md
@@ -1,0 +1,73 @@
+# Portfolio Improvements — Manual Functional QA
+
+**Task**: T-a2d4de3e — Verify portfolio improvements
+**Date**: 2026-05-03
+**Branch**: `master` @ `80b97094`
+**Blocked-by predecessor**: T-7b064ba3 — `Implement portfolio improvements` (status=completed, verified 2026-05-03)
+
+## 1. Automated checks
+
+```
+$ npm run automate:full
+> sync:all → lint → typecheck → test → build → validate-cloudflare-native
+
+✅ all stages passed
+worker.js: 790.05 KB
+build time: 0.23s
+```
+
+Subordinate runs (executed independently for record):
+
+| Stage                                       | Result            |
+| ------------------------------------------- | ----------------- |
+| `npm run lint` (eslint .)                   | clean             |
+| `npm run typecheck` (tsc --noEmit)          | clean             |
+| `npx jest tests/unit/portfolio-worker --runInBand` | 27 suites, 716 tests passed |
+| `npm run build:portfolio`                   | worker.js 790.05 KB |
+| `npx wrangler deploy --dry-run`             | success — bindings resolved |
+| `go run ./tools/ci/validate-cloudflare-native.go` | OK |
+
+## 2. Manual functional QA via Miniflare
+
+`apps/portfolio/worker.js` was loaded directly into a Miniflare runtime
+(compatibilityDate `2026-02-21`, `nodejs_compat`). Three locale routes were
+fetched and inspected:
+
+| URL                                | Status | Bytes  | `<html lang>` | `<title>`                                                |
+| ---------------------------------- | ------ | ------ | ------------- | -------------------------------------------------------- |
+| `https://resume.jclee.me/`         | 200    | 148984 | `ko`          | 이재철 - DevSecOps/SRE/Platform Engineer                 |
+| `https://resume.jclee.me/en/`      | 200    | 95390  | `en`          | Jaecheol Lee - DevSecOps/SRE/Platform Engineer           |
+| `https://resume.jclee.me/ja/`      | 200    | 148085 | `ja`          | イ・ジェチョル - DevSecOps/SRE/Platform Engineer         |
+
+All three locales render the expected language, the Japanese page is a
+distinct artifact (≠ the Korean default), and no fetch returned 4xx/5xx.
+
+Routing logic was independently exercised at the unit level:
+
+```
+getPortfolioTargetPath('/ja')  → '/ja/'
+getPortfolioTargetPath('/ja/') → '/ja/'
+LOCALE_ROUTES.has('/ja')       → true
+LOCALE_ROUTES.has('/ja/')      → true
+```
+
+## 3. Production state — separate operational issue
+
+`https://resume.jclee.me/ja/` currently returns HTTP 301 → `/`, because the
+upstream `Workers Builds: resume` Cloudflare integration is failing in 1
+second on every commit (reproduced on `master` independently of PR #74). The
+production Worker therefore reflects an older artifact that predates the
+Japanese locale change.
+
+This is a Cloudflare Workers Builds infrastructure issue, not a code defect:
+the merged code, locally built worker.js, and Miniflare-driven request/response
+inspection all behave correctly. The deploy gap is recorded as the follow-up
+task `Workers Builds infra` (see `.sisyphus/evidence/workers-builds-infra.md`).
+
+## 4. Verdict
+
+**T-a2d4de3e PASS.** Portfolio improvements verified end-to-end under
+the automated pipeline, full unit test suite, and live Miniflare functional
+QA across `ko`, `en`, and `ja` locales. The only outstanding gap is
+production deploy, which is gated by an independent Cloudflare infra issue
+documented separately.

--- a/.sisyphus/evidence/resume-pdf-cta-verification.md
+++ b/.sisyphus/evidence/resume-pdf-cta-verification.md
@@ -1,0 +1,111 @@
+# Resume PDF CTA Target Verification
+
+**Task**: T-2dd3bbba — Verify resume PDF CTA target
+**Date**: 2026-05-03
+**Branch**: `master` @ `80b97094`
+
+## Acceptance Criteria
+
+PDF CTA must resolve to a non-empty generated PDF route, OR the blocker must
+be documented with evidence.
+
+## Findings
+
+### 1. PDF source artifacts exist
+
+The PDF generator (`tools/scripts/build/pdf-generator.go`) emits resume PDFs
+into `packages/data/resumes/`:
+
+- `packages/data/resumes/master/resume_final.pdf` — 164,212 bytes, PDF v1.5
+- Variant outputs (toss, general, technical, security, short, …) are produced
+  on demand under `packages/data/resumes/generated/`.
+
+`packages/data/resumes/master/resume_final.pdf` is the canonical artifact and
+is currently present in the working tree.
+
+### 2. Portfolio worker does not surface a PDF CTA
+
+The portfolio HTML (`apps/portfolio/index.html`) contains a `download` CLI
+command at lines 1351–1361:
+
+```js
+terminalCommands['download'] = function () {
+  var pdfLink = document.querySelector(
+    '.hero-download a[download], .resume-download a[download]'
+  );
+  var url = pdfLink && pdfLink.getAttribute('href');
+  if (!url || url.indexOf('<!--') !== -1) {
+    return '> Resume PDF URL is not available yet.';
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+  return '> Opening resume PDF in a new tab...';
+};
+```
+
+The selector targets `.hero-download a[download]` or `.resume-download
+a[download]`. Inspection of `apps/portfolio/index.html` (lines 664–668) shows
+the `.hero-download` container only renders a `#contact` anchor:
+
+```html
+<div class="hero-download" role="group" aria-label="채용 문의 옵션">
+  <a href="#contact" class="link-subtle" aria-label="채용 또는 면접 문의하기"
+    >채용·면접 문의하기</a>
+</div>
+```
+
+There is no `<a download>` element anywhere in the source HTML, and the
+generated `apps/portfolio/worker.js` (790.05 KB) contains no `.pdf` references
+either. Production smoke test on 2026-05-03:
+
+```
+curl -sS https://resume.jclee.me/ | grep -c "\.pdf"   # → 0
+```
+
+### 3. Worker assets do not include the PDF
+
+`wrangler.jsonc` declares `assets.directory = "apps/portfolio/assets"`. The
+asset directory contents are:
+
+```
+apple-touch-icon.png
+favicon-32x32.png
+favicon.svg
+fonts/
+icon-192.png
+icon-192.svg
+icon-512.png
+icon-512.svg
+```
+
+No PDF is staged into the asset bundle, so even if the HTML linked
+`/resume.pdf`, the worker would respond 404.
+
+## Blocker
+
+The PDF CTA cannot resolve to a non-empty PDF route in the current pipeline
+because:
+
+1. The portfolio HTML never renders a `<a download href="…">` element.
+2. The Cloudflare Workers asset bundle does not contain any PDF file.
+3. The PDF generator writes to `packages/data/resumes/master/` outside the
+   `apps/portfolio/assets/` tree consumed by the worker.
+
+## Required follow-up (out of scope for this task)
+
+To unblock the CTA, a future task must:
+
+1. Copy the generated PDF (e.g.
+   `packages/data/resumes/master/resume_final.pdf`) into
+   `apps/portfolio/assets/resume.pdf` during `npm run build:portfolio`.
+2. Update `apps/portfolio/index.html` `.hero-download` to render
+   `<a download href="/resume.pdf">이력서 PDF 다운로드</a>` (and the English
+   and data-driven Japanese build equivalents).
+3. Re-run `node generate-worker.js` and verify
+   `apps/portfolio/worker.js` references `/resume.pdf`.
+
+## Verdict
+
+**Blocker documented.** The acceptance criteria's "OR" branch is satisfied:
+the PDF CTA does not resolve to a non-empty PDF route, and the missing
+pipeline links are recorded above with file paths and line numbers so a
+follow-up task can act without rediscovery.

--- a/.sisyphus/evidence/workers-builds-infra.md
+++ b/.sisyphus/evidence/workers-builds-infra.md
@@ -1,0 +1,75 @@
+# Workers Builds: resume — Infrastructure Failure
+
+**Status**: Pre-existing infra issue, blocking production deploys
+**Date observed**: 2026-05-03
+**Branch**: `master` @ `80b97094` (also reproduced on prior master commits)
+
+## Symptom
+
+The `Workers Builds: resume` check on Cloudflare Workers Builds fails in
+~1 second on every push to `master` (start_at == completed_at). Example:
+
+```
+{
+  "name": "Workers Builds: resume",
+  "conclusion": "failure",
+  "started_at":   "2026-05-03T08:19:48Z",
+  "completed_at": "2026-05-03T08:19:48Z",
+  "html_url": "https://github.com/jclee941/resume/runs/74101145548"
+}
+```
+
+Logs are hosted on Cloudflare dashboard at:
+`https://dash.cloudflare.com/.../workers/services/view/resume/production/builds/<id>`
+and are not accessible via the GitHub Checks API or `gh run` CLI.
+
+## Impact
+
+- `https://resume.jclee.me/ja/` returns HTTP 301 → `/` because the
+  Cloudflare-deployed artifact pre-dates the Japanese locale change merged
+  in PR #74 (`80b97094`).
+- All other production routes continue to serve the older artifact.
+- Local `wrangler deploy --dry-run` succeeds, so the issue is environmental
+  (Cloudflare Workers Builds runner config / secrets / build command), not
+  a wrangler.jsonc or worker.js defect.
+
+## Reproduction
+
+| Branch                      | HEAD       | Workers Builds         |
+| --------------------------- | ---------- | ---------------------- |
+| `master` (post-merge #74)   | `80b97094` | failure (1s)           |
+| `master` (pre-merge #74)    | `d1e62878` | failure (1s)           |
+| `feat/japanese-portfolio-locale` | `e419e01c` | failure (1s)      |
+
+The 1-second failure pattern indicates the build runner exits before
+executing any build command — typically a missing secret, an
+unsupported config field, or a queue/permission rejection on the
+Cloudflare side.
+
+## Required follow-up (NEW TASK)
+
+A new operational task should:
+
+1. Open the failing Cloudflare Workers Builds run in the dashboard and
+   capture the actual error string.
+2. Confirm whether the Cloudflare account has the Workers Builds beta
+   enabled for the `resume` worker.
+3. Validate the build command configured on Cloudflare side
+   (`npm run build:portfolio` or equivalent).
+4. Verify `CF_API_TOKEN` / `CF_ACCOUNT_ID` parity with `wrangler.jsonc`
+   account `a8d9c67f586acdd15eebcc65ca3aa5bb`.
+5. After fixing, push a no-op commit (e.g. README touch) and confirm the
+   `Workers Builds: resume` check turns green AND
+   `https://resume.jclee.me/ja/` responds with `<html lang="ja">`.
+
+## Verification target
+
+Once resolved, the production smoke test should match the local
+Miniflare inspection recorded in
+`.sisyphus/evidence/portfolio-improvements-manual-qa.md`:
+
+| URL                                | Expected lang | Expected title fragment                        |
+| ---------------------------------- | ------------- | ---------------------------------------------- |
+| `https://resume.jclee.me/`         | `ko`          | `이재철 - DevSecOps/SRE/Platform Engineer`     |
+| `https://resume.jclee.me/en/`      | `en`          | `Jaecheol Lee - DevSecOps/SRE/Platform Engineer` |
+| `https://resume.jclee.me/ja/`      | `ja`          | `イ・ジェチョル - DevSecOps/SRE/Platform Engineer` |


### PR DESCRIPTION
## Summary

Adds Sisyphus evidence files documenting completion verdicts for in-progress tasks closed in this iteration of the ultrawork loop.

## Files

- `.sisyphus/evidence/resume-pdf-cta-verification.md` — T-2dd3bbba: PDF CTA blocker documented (no `<a download>` in HTML, no PDF in worker assets, generator outputs outside the worker bundle).
- `.sisyphus/evidence/portfolio-improvements-manual-qa.md` — T-a2d4de3e: full automate:full pass + Miniflare-driven manual QA confirming ko/en/ja locales render correctly with distinct titles and `lang` attributes.
- `.sisyphus/evidence/workers-builds-infra.md` — T-c8a18b63 follow-up: `Workers Builds: resume` failing in ~1s on master (pre-existing infra issue blocking production deploy of the Japanese locale; reproduced on prior master HEADs).

## Verification

- `npm run automate:full` → green
- `npx jest tests/unit/portfolio-worker --runInBand` → 27 suites, 716 tests pass
- Miniflare `dispatchFetch` over `apps/portfolio/worker.js`:
  - `/` → HTTP 200, `<html lang="ko">`, `이재철 - DevSecOps/SRE/Platform Engineer`
  - `/en/` → HTTP 200, `<html lang="en">`, `Jaecheol Lee - DevSecOps/SRE/Platform Engineer`
  - `/ja/` → HTTP 200, `<html lang="ja">`, `イ・ジェチョル - DevSecOps/SRE/Platform Engineer`

No code changes; documentation/evidence only.