### PR TITLE
feat(profile-sync): map coverLetter to JobKorea M_Career_Text

### DIFF
--- a/apps/job-server/scripts/profile-sync/jobkorea-sections.js
+++ b/apps/job-server/scripts/profile-sync/jobkorea-sections.js
@@ -212,7 +212,15 @@ export function mapCareersToFormFields(ssot, indices) {
   });
 
   pushField(fields, 'Career.index', keys.slice(0, careers.length).join(','));
-  pushField(fields, 'UserResume.M_Career_Text', '');
+  // Pull cover letter (자기소개서) from SSoT and feed JobKorea "경력요약" field.
+  // Falls back to empty string when coverLetter is absent.
+  const coverParagraphs = ssot?.coverLetter?.ko?.paragraphs;
+  const coverHeadline = ssot?.coverLetter?.ko?.headline;
+  const coverClosing = ssot?.coverLetter?.ko?.closing;
+  const coverText = Array.isArray(coverParagraphs) && coverParagraphs.length
+    ? [coverHeadline, '', ...coverParagraphs, '', coverClosing].filter(Boolean).join('\n\n').slice(0, 2000)
+    : '';
+  pushField(fields, 'UserResume.M_Career_Text', coverText);
   pushField(fields, 'UserResume.M_Career_Text_Stat', '1');
   pushField(fields, 'InputStat.CareerInputStat', 'True');
   return fields;


### PR DESCRIPTION
Maps SSoT `coverLetter.ko` (5-paragraph 자기소개서) to JobKorea's 경력요약 field (`UserResume.M_Career_Text`).

Note: full `--apply` still requires JobKorea's M_MainField (담당직무 직무코드) which is a client-side Backbone popup with no public REST endpoint. User must select job category once per career manually; subsequent syncs preserve codes via existing `change-detection.js` regex. See `.sisyphus/evidence/jobkorea-sync-handoff.md`.