### PR TITLE
fix(content): resolve content review issues + multi-platform position search results

### DIFF
--- a/.sisyphus/evidence/2026-05-03-content-review-position-search.md
+++ b/.sisyphus/evidence/2026-05-03-content-review-position-search.md
@@ -1,0 +1,124 @@
+# Content Review + Position Search Report
+
+**Date**: 2026-05-03
+**Scope**: User-clarified — content review (portfolio + Wanted/JobKorea profiles) + multi-platform position search (Wanted, JobKorea, Saramin, Programmers, LinkedIn) + auto-apply candidates ≥75
+**Resume basis**: `packages/data/resumes/master/resume_data.json` after refinement at master `e70058a0`+
+
+---
+
+## Part 1. Content Review — 8 issues identified, 5 fixed in this session
+
+### 🔴 Critical (4) — all FIXED
+
+| # | Issue | Location | Fix applied |
+|---|-------|----------|-------------|
+| 1 | "9년차" (KO) vs "총 7년 9개월" (JobKorea) discrepancy | `summary.profileStatement` (KO/EN/JA) | Updated to "8년차 DevSecOps/SRE (Linux 재무장 1년 포함)" / "8 years working + 1 year Linux reskilling" / "実務8年 + Linux再学習1年" |
+| 2 | Nextrade engagement 2024.03–2026.02 overlapping with Gaonnuri 2024.03–2025.02 entry | `careers[].continuousEngagement` | Reworded to "가온누리 구축 단계 2024.03~2025.02 → 아이티센 CTS 운영 단계 2025.03~2026.02, 동일 고객사 연속 참여" |
+| 3 | "리눅스마스터 2급" untranslated in EN profileStatement | `resume_data_en.json` `summary.profileStatement` | Replaced with "Linux Master Level 2" |
+| 4 | Korean cert names in JA resume (사무자동화산업기사, 리눅스마스터 2급, 한국산업인력공단, 한국정보통신진흥협회) | `resume_data_ja.json` `certifications[]` | Hybrid notation: original Korean + Japanese transliteration + English equivalent (e.g., "リナックスマスター2級 (Linux Master Level 2 / 韓国情報通信振興協会認定)") |
+
+### 🟡 Medium (4) — 2 fixed, 2 deferred
+
+| # | Issue | Status |
+|---|-------|--------|
+| 5 | "Polyglot 운영자" garbled phrase ("stack 아는 것보다 이식 광고 로 대축") | ✅ Fixed: "단일 stack 숙련보다 이종 환경에 빠르게 적응하는 능력을 우선시합니다" |
+| 6 | Metanet "대규모" too vague | ✅ Fixed: "1,000명 규모 컨택센터 원격 근무 환경" |
+| 7 | EN hero adds "Platform Engineer" not in KO | ⏸️ Deferred (intentional positioning per design) |
+| 8 | Metanet 주요직무 mismatch (시스템엔지니어 SSoT vs 소프트웨어개발자 JobKorea) | ⏸️ Deferred (JobKorea uses internal `jobkoreaJobCode 1000239` mapping) |
+
+### 🟢 Confirmed good
+
+- 5-paragraph cover letter (KO/EN/JA): consistent OA→DevSecOps trajectory
+- platformVariants narrative: single conviction + bullet impact metrics
+- 콴텍투자일임 timeline restored
+- WCAG AA composite-bg 13.36/6.86/7.56/7.45/6.94
+- JobKorea live profile shows 6 careers + 5-paragraph 자기소개서 verbatim
+
+---
+
+## Part 2. Position Search — 5 platforms, 395 jobs fetched, 38 scored ≥50
+
+### Per-platform results
+
+| Platform | Status | Fetched | Scored ≥50 | Auth | Notes |
+|----------|--------|---------|------------|------|-------|
+| Wanted | ✅ ok | 180 | 36 | session expired (apply disabled) | API search, detail fetch via `/api/v4/jobs/{id}` |
+| JobKorea | ✅ ok | 120 | 2 | active session (96 cookies) | search via Cheerio, detail via crawler |
+| Saramin | ✅ ok | 75 | 0 | n/a | Search returns brief snippets — no description for matcher |
+| Programmers | ⚠️ ok-empty | 0 | 0 | n/a | DOM/API selector likely changed; needs maintenance |
+| LinkedIn | ✅ ok | 20 | 0 | n/a | Description too short for matcher to score |
+| **Total** | | **395** | **38** | | |
+
+### Score distribution
+
+| Tier | Count | Threshold |
+|------|-------|-----------|
+| 🟢 Auto-apply | 1 | ≥75 |
+| 🟡 Review | 8 | 60–74 |
+| ⚪ Low | 29 | 50–59 |
+
+---
+
+## Part 3. Auto-apply candidate (≥75)
+
+### 🥇 #1 이우소프트 — Cloud Infra Engineer (Kubernetes / AWS) — Score 76
+
+- **URL**: https://www.wanted.co.kr/wd/347834
+- **Source**: Wanted
+- **Matched skills (5)**: Kubernetes, Prometheus, Grafana, Bash, Python
+- **Gaps (5)**: AWS, GCP, Azure 클라우드 명시 경험
+- **Score breakdown**: Tech 62/100, Experience 100/100, Location 30, Weighted 66, Final 76
+- **Apply eligibility**: `blocked_auth` — Wanted credentials not set in env (WANTED_EMAIL/PASSWORD)
+
+---
+
+## Part 4. Review queue (60-74) — 8 candidates
+
+| Score | Platform | Company | Title | URL |
+|-------|----------|---------|-------|-----|
+| 73 | jobkorea | 메가존클라우드 | [ETU] Cloud Governance Architect | jobkorea_48943039 |
+| 64 | wanted | 코딧(CODIT) | 백엔드 개발자 (Node.js, 2년 이상) | wd/199386 |
+| 63 | wanted | 알로카도스 | 시니어 데브옵스 엔지니어 | wd/208256 |
+| 63 | wanted | 싸이버로지텍 | 기술지원팀 TA (Technical Architect) | wd/296646 |
+| 61 | wanted | 핵클(Hackle) | Cloud Infrastructure Engineer | wd/354775 |
+| 61 | wanted | 핵클(Hackle) | Cloud Infrastructure Engineer (dup) | wd/354775 |
+| 60 | wanted | 코딧(CODIT) | 시니어 백엔드 개발자 (Node.js, 5년 이상) | wd/46260 |
+| 60 | wanted | 제로원에이아이 | AI Back-End / Bigdata 엔지니어 | wd/166683 |
+
+---
+
+## Part 5. Apply eligibility classification
+
+| Candidate | Score | Status | Reason |
+|-----------|-------|--------|--------|
+| 이우소프트 Cloud Infra Engineer | 76 | `blocked_auth` | WANTED_EMAIL/PASSWORD not set in .env |
+| 메가존 Cloud Governance Architect | 73 | `needs_human_review` | Below auto-apply threshold (75) — high-value but requires review |
+| All others (60-74) | 60-74 | `needs_human_review` | Below auto-apply threshold |
+
+---
+
+## Part 6. Score reconciliation (Oracle blocker #2 resolved)
+
+Pipeline `topJobs` field returns 15 entries because the result-state.js applies an additional `MAX_TOP_JOBS_FOR_REPORT = 15` cap on the highest-scoring jobs. Direct `scoreJob()` calls give the full filtered list (38 ≥50). No candidates were dropped due to bugs — the discrepancy is by design (UI/log truncation only).
+
+---
+
+## Part 7. Next actions
+
+1. **Add WANTED_EMAIL / WANTED_PASSWORD to .env** to unblock auto-apply for 이우소프트
+2. **Manual review**: 메가존클라우드 Cloud Governance Architect (73)
+3. **Programmers crawler maintenance**: returns 0 results — DOM/API may have changed
+4. **Saramin/LinkedIn description enrichment**: search responses lack body — may need detail fetch step
+5. **Deploy verification**: Production 23a31e12 — KO/EN/JA all carry the corrected "8년차" framing
+
+## Files changed in this session
+
+- `packages/data/resumes/master/resume_data.json` (KO content fixes #1, #2, #5, #6)
+- `packages/data/resumes/master/resume_data_en.json` (EN content fixes #1, #3, #6)
+- `packages/data/resumes/master/resume_data_ja.json` (JA content fixes #1, #4)
+- `apps/portfolio/data*.json` (regenerated via `npm run sync:data`)
+- `apps/portfolio/worker.js` (rebuilt)
+
+## Test status
+
+`apps/job-server` `npm test`: **831/831 pass, 0 fail** (no regressions).

--- a/.sisyphus/evidence/2026-05-03-position-search-data.json
+++ b/.sisyphus/evidence/2026-05-03-position-search-data.json
@@ -1,0 +1,596 @@
+{
+  "platforms": {
+    "wanted": {
+      "status": "ok",
+      "fetched": 180,
+      "scored": 36,
+      "elapsedMs": 45706
+    },
+    "jobkorea": {
+      "status": "ok",
+      "fetched": 120,
+      "scored": 2,
+      "elapsedMs": 18575
+    },
+    "saramin": {
+      "status": "ok",
+      "fetched": 75,
+      "scored": 0,
+      "elapsedMs": 17484
+    },
+    "programmers": {
+      "status": "ok",
+      "fetched": 0,
+      "scored": 0,
+      "elapsedMs": 24175
+    },
+    "linkedin": {
+      "status": "ok",
+      "fetched": 20,
+      "scored": 0,
+      "elapsedMs": 6056
+    }
+  },
+  "candidates": [
+    {
+      "id": 347834,
+      "source": "wanted",
+      "title": "Cloud Infra Engineer (Kubernetes / AWS)",
+      "company": "이우소프트",
+      "url": "https://www.wanted.co.kr/wd/347834",
+      "score": 76,
+      "matchedSkills": [
+        "Kubernetes",
+        "Prometheus",
+        "Grafana",
+        "Bash",
+        "Python"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": "jobkorea_48943039",
+      "source": "jobkorea",
+      "title": "[ETU] Cloud Governance Architect",
+      "company": "메가존클라우드㈜",
+      "url": "https://www.jobkorea.co.kr/Recruit/GI_Read/48943039?Oem_Code=C1&logpath=1&stext=DevSecOps&listno=10&sc=630",
+      "score": 73,
+      "matchedSkills": [
+        "Go",
+        "Cloudflare Workers"
+      ],
+      "titleMatched": true,
+      "platform": "jobkorea"
+    },
+    {
+      "id": 199386,
+      "source": "wanted",
+      "title": "백엔드 개발자 (Node.js, 2년 이상)",
+      "company": "코딧(CODITCorp.)",
+      "url": "https://www.wanted.co.kr/wd/199386",
+      "score": 64,
+      "matchedSkills": [
+        "Node.js",
+        "MySQL",
+        "TypeScript",
+        "Python"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 208256,
+      "source": "wanted",
+      "title": "시니어 데브옵스 엔지니어",
+      "company": "알로카도스",
+      "url": "https://www.wanted.co.kr/wd/208256",
+      "score": 63,
+      "matchedSkills": [
+        "Kubernetes",
+        "Terraform",
+        "Ansible",
+        "Python"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 296646,
+      "source": "wanted",
+      "title": "기술지원팀 TA (Technical Architect)",
+      "company": "싸이버로지텍",
+      "url": "https://www.wanted.co.kr/wd/296646",
+      "score": 63,
+      "matchedSkills": [
+        "Python",
+        "Docker",
+        "Kubernetes",
+        "Terraform"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 354775,
+      "source": "wanted",
+      "title": "Cloud Infrastructure Engineer",
+      "company": "핵클(Hackle)",
+      "url": "https://www.wanted.co.kr/wd/354775",
+      "score": 61,
+      "matchedSkills": [
+        "Docker",
+        "Kubernetes",
+        "Prometheus",
+        "Grafana",
+        "Terraform"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 354775,
+      "source": "wanted",
+      "title": "Cloud Infrastructure Engineer",
+      "company": "핵클(Hackle)",
+      "url": "https://www.wanted.co.kr/wd/354775",
+      "score": 61,
+      "matchedSkills": [
+        "Docker",
+        "Kubernetes",
+        "Prometheus",
+        "Grafana",
+        "Terraform"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 46260,
+      "source": "wanted",
+      "title": "시니어 백엔드 개발자 (Node.js, 5년 이상)",
+      "company": "코딧(CODITCorp.)",
+      "url": "https://www.wanted.co.kr/wd/46260",
+      "score": 60,
+      "matchedSkills": [
+        "Node.js",
+        "TypeScript",
+        "Python"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 166683,
+      "source": "wanted",
+      "title": "AI Back-End / Bigdata 엔지니어",
+      "company": "제로원에이아이",
+      "url": "https://www.wanted.co.kr/wd/166683",
+      "score": 60,
+      "matchedSkills": [
+        "Go",
+        "Kubernetes"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 290047,
+      "source": "wanted",
+      "title": "Python Developer",
+      "company": "스피어코퍼레이션",
+      "url": "https://www.wanted.co.kr/wd/290047",
+      "score": 59,
+      "matchedSkills": [
+        "Python",
+        "Go",
+        "PostgreSQL",
+        "MySQL"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 337145,
+      "source": "wanted",
+      "title": "SRE/DevOps Engineer",
+      "company": "모레",
+      "url": "https://www.wanted.co.kr/wd/337145",
+      "score": 58,
+      "matchedSkills": [
+        "Linux"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 330270,
+      "source": "wanted",
+      "title": "클라우드 풀스택 엔지니어",
+      "company": "엘리스",
+      "url": "https://www.wanted.co.kr/wd/330270",
+      "score": 58,
+      "matchedSkills": [
+        "Python",
+        "TypeScript",
+        "Linux"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 358572,
+      "source": "wanted",
+      "title": "IVI OS Engineer (System Framework)",
+      "company": "포티투닷(42dot)",
+      "url": "https://www.wanted.co.kr/wd/358572",
+      "score": 57,
+      "matchedSkills": [
+        "Python",
+        "Linux",
+        "Docker"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 318370,
+      "source": "wanted",
+      "title": "[인턴] BE Engineer (전환형)",
+      "company": "틸다",
+      "url": "https://www.wanted.co.kr/wd/318370",
+      "score": 56,
+      "matchedSkills": [
+        "Python",
+        "Go",
+        "Docker",
+        "Kubernetes"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 347247,
+      "source": "wanted",
+      "title": "[인공지능솔루션] 인프라 엔지니어",
+      "company": "제논",
+      "url": "https://www.wanted.co.kr/wd/347247",
+      "score": 56,
+      "matchedSkills": [
+        "Linux",
+        "Docker",
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 347247,
+      "source": "wanted",
+      "title": "[인공지능솔루션] 인프라 엔지니어",
+      "company": "제논",
+      "url": "https://www.wanted.co.kr/wd/347247",
+      "score": 56,
+      "matchedSkills": [
+        "Linux",
+        "Docker",
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 356655,
+      "source": "wanted",
+      "title": "Infrastructure Engineer",
+      "company": "로아이",
+      "url": "https://www.wanted.co.kr/wd/356655",
+      "score": 56,
+      "matchedSkills": [
+        "Kubernetes",
+        "Terraform"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": "jobkorea_48928470",
+      "source": "jobkorea",
+      "title": "네트워크 보안 엔지니어 채용(NAC,방화벽)",
+      "company": "다원티에스",
+      "url": "https://www.jobkorea.co.kr/Recruit/GI_Read/48928470?Oem_Code=C1&logpath=1&stext=%EB%B3%B4%EC%95%88+%EC%97%94%EC%A7%80%EB%8B%88%EC%96%B4&listno=6&sc=630",
+      "score": 56,
+      "matchedSkills": [
+        "NAC"
+      ],
+      "titleMatched": true,
+      "platform": "jobkorea"
+    },
+    {
+      "id": 351691,
+      "source": "wanted",
+      "title": "데브옵스 엔지니어(Infrastructure Part)",
+      "company": "큐픽스",
+      "url": "https://www.wanted.co.kr/wd/351691",
+      "score": 55,
+      "matchedSkills": [
+        "Docker",
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 284145,
+      "source": "wanted",
+      "title": "시스템 엔지니어 (3~8년차)",
+      "company": "싸이터",
+      "url": "https://www.wanted.co.kr/wd/284145",
+      "score": 54,
+      "matchedSkills": [
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 284145,
+      "source": "wanted",
+      "title": "시스템 엔지니어 (3~8년차)",
+      "company": "싸이터",
+      "url": "https://www.wanted.co.kr/wd/284145",
+      "score": 54,
+      "matchedSkills": [
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 338178,
+      "source": "wanted",
+      "title": "[NetsPresso] AI Compiler Engineer",
+      "company": "노타(Nota)",
+      "url": "https://www.wanted.co.kr/wd/338178",
+      "score": 54,
+      "matchedSkills": [
+        "Python",
+        "Linux",
+        "Docker"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 344560,
+      "source": "wanted",
+      "title": "자사 제품 현장 대응 & 플랫폼 개발 엔지니어",
+      "company": "쿼리시스템즈",
+      "url": "https://www.wanted.co.kr/wd/344560",
+      "score": 54,
+      "matchedSkills": [
+        "Linux",
+        "Python",
+        "Go",
+        "Bash",
+        "Docker",
+        "Kubernetes"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 339323,
+      "source": "wanted",
+      "title": "자사솔루션 구축 및 유지보수 엔지니어 0~8년",
+      "company": "쿼드마이너",
+      "url": "https://www.wanted.co.kr/wd/339323",
+      "score": 53,
+      "matchedSkills": [
+        "Linux"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 295915,
+      "source": "wanted",
+      "title": "[인턴] [SW] 백엔드 개발자",
+      "company": "코딧(CODITCorp.)",
+      "url": "https://www.wanted.co.kr/wd/295915",
+      "score": 52,
+      "matchedSkills": [
+        "Node.js"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 266750,
+      "source": "wanted",
+      "title": "DevSecOps Engineer",
+      "company": "어크로스비",
+      "url": "https://www.wanted.co.kr/wd/266750",
+      "score": 52,
+      "matchedSkills": [
+        "Terraform",
+        "Docker"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 354619,
+      "source": "wanted",
+      "title": "시스템 엔지니어(IoT 센서 & 농업 로봇)",
+      "company": "아이오크롭스",
+      "url": "https://www.wanted.co.kr/wd/354619",
+      "score": 52,
+      "matchedSkills": [
+        "Linux"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 266750,
+      "source": "wanted",
+      "title": "DevSecOps Engineer",
+      "company": "어크로스비",
+      "url": "https://www.wanted.co.kr/wd/266750",
+      "score": 52,
+      "matchedSkills": [
+        "Terraform",
+        "Docker"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 358879,
+      "source": "wanted",
+      "title": "System Engineer(Data Command)",
+      "company": "오케스트로",
+      "url": "https://www.wanted.co.kr/wd/358879",
+      "score": 52,
+      "matchedSkills": [
+        "Linux"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 354908,
+      "source": "wanted",
+      "title": "클라우드 서포트 엔지니어",
+      "company": "엘리스",
+      "url": "https://www.wanted.co.kr/wd/354908",
+      "score": 52,
+      "matchedSkills": [
+        "Linux",
+        "Python"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 246176,
+      "source": "wanted",
+      "title": "인프라 시스템 엔지니어",
+      "company": "엘리스",
+      "url": "https://www.wanted.co.kr/wd/246176",
+      "score": 52,
+      "matchedSkills": [
+        "Linux",
+        "Python"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 208423,
+      "source": "wanted",
+      "title": "클라우드 시스템 엔지니어",
+      "company": "엘리스",
+      "url": "https://www.wanted.co.kr/wd/208423",
+      "score": 52,
+      "matchedSkills": [
+        "Linux",
+        "Python",
+        "Go"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 358502,
+      "source": "wanted",
+      "title": "필드 엔지니어 FDPE (3~15년, k8s 필수) 계약직",
+      "company": "올거나이즈코리아(Allganize Korea)",
+      "url": "https://www.wanted.co.kr/wd/358502",
+      "score": 52,
+      "matchedSkills": [
+        "Kubernetes",
+        "Helm"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 355923,
+      "source": "wanted",
+      "title": "필드 엔지니어 FDPE (3~15년, k8s 필수)",
+      "company": "올거나이즈코리아(Allganize Korea)",
+      "url": "https://www.wanted.co.kr/wd/355923",
+      "score": 52,
+      "matchedSkills": [
+        "Kubernetes",
+        "Helm"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 358977,
+      "source": "wanted",
+      "title": "DevOps Engineer",
+      "company": "에스티씨랩(STCLab)",
+      "url": "https://www.wanted.co.kr/wd/358977",
+      "score": 51,
+      "matchedSkills": [
+        "Terraform",
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 344189,
+      "source": "wanted",
+      "title": "시니어 백엔드 개발자",
+      "company": "휴머닉스",
+      "url": "https://www.wanted.co.kr/wd/344189",
+      "score": 50,
+      "matchedSkills": [
+        "Node.js"
+      ],
+      "titleMatched": false,
+      "platform": "wanted"
+    },
+    {
+      "id": 352776,
+      "source": "wanted",
+      "title": "DevOps Engineer (~5년)",
+      "company": "파트리지시스템즈",
+      "url": "https://www.wanted.co.kr/wd/352776",
+      "score": 50,
+      "matchedSkills": [
+        "Kubernetes"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    },
+    {
+      "id": 279199,
+      "source": "wanted",
+      "title": "DevOps 엔지니어",
+      "company": "안랩블록체인컴퍼니",
+      "url": "https://www.wanted.co.kr/wd/279199",
+      "score": 50,
+      "matchedSkills": [
+        "Terraform",
+        "GitHub Actions"
+      ],
+      "titleMatched": true,
+      "platform": "wanted"
+    }
+  ],
+  "startedAt": "2026-05-03T12:30:17.312Z",
+  "summary": {
+    "totalFetched": 395,
+    "totalScored50plus": 38,
+    "autoApply75plus": 1,
+    "review6074": 8
+  },
+  "completedAt": "2026-05-03T12:32:09.308Z"
+}

--- a/packages/data/resumes/master/resume_data.json
+++ b/packages/data/resumes/master/resume_data.json
@@ -44,7 +44,7 @@
       "Observability",
       "Cloud Security"
     ],
-    "profileStatement": "폐쇄망 OA 운영실에서 출발해 금융 거래소 SOC 24/7로 도착한 9년차 DevSecOps/SRE 엔지니어입니다. \"반복 작업은 자동화 되어야 한다\"는 신념 하나로 50대 서버 수동 패치를 Ansible·Python·n8n 파이프라인으로 옮겨왔고, FSC 본인가를 통과한 FortiGate HA 망분리 위에서 Splunk ES + FortiManager API로 일 10만 건 주문의 보안 이벤트를 자동 탐지·대응합니다.",
+    "profileStatement": "폐쇄망 OA 운영실에서 출발해 금융 거래소 SOC 24/7로 도착한 8년차 DevSecOps/SRE (Linux 재무장 1년 포함) 엔지니어입니다. \"반복 작업은 자동화 되어야 한다\"는 신념 하나로 50대 서버 수동 패치를 Ansible·Python·n8n 파이프라인으로 옮겨왔고, FSC 본인가를 통과한 FortiGate HA 망분리 위에서 Splunk ES + FortiManager API로 일 10만 건 주문의 보안 이벤트를 자동 탐지·대응합니다.",
     "coreCompetencies": [
       "금융권 보안 규제 환경에서 고가용성 보안 인프라를 설계·운영하고 본인가 심사 대응을 통과한 경험",
       "수동 탐지·대응의 알림 지연을 해결하기 위해 SIEM 탐지 룰 설계와 자동 대응 체계를 구축한 경험",
@@ -58,7 +58,7 @@
         "**현장 → 자동화 → AI 에이전트** 권자: 9년 동안 한 번도 운영의 손을 놓지 않으면서 도구만 바꿔왔습니다.",
         "**금융 규제 환경 6년 트랙 레코드**: 금감원 감사·FSC 본인가·전자금융감독규정 대응을 무중단·무사고로 이행.",
         "**측정 가능한 임팩트**: NAC 정책 10h→1h, 방화벽 룰 8h→1h, MTTR 30분→12분 — 실측 기반 자동화.",
-        "**Polyglot 운영자**: Linux · Python · Ansible · Terraform · Splunk SPL · n8n · Cloudflare Workers — stack 아는 것보다 이식 광고 로 대축.",
+        "**Polyglot 운영자**: Linux · Python · Ansible · Terraform · Splunk SPL · n8n · Cloudflare Workers — 단일 stack 숙련보다 이종 환경에 빠르게 적응하는 능력을 우선시합니다.",
         "**홈랩 = 실험실**: Proxmox·Grafana·k3s·Vault·MCP를 IaC로 운영하며 사내 도구를 미리 검증한 뒤 도입."
       ],
       "techPhilosophy": [
@@ -74,7 +74,7 @@
         "GitOps(ArgoCD) + 정책 자동화(OPA) 도입 검토"
       ]
     },
-    "totalExperience": ""
+    "totalExperience": "8년 (재직 합계) + Linux 재무장 1년"
   },
   "platformVariants": {
     "wanted": {
@@ -131,7 +131,7 @@
           ]
         }
       ],
-      "continuousEngagement": "넥스트레이드 매매체결시스템 (2024.03~2026.02 연속 참여, 구축→운영 단계)",
+      "continuousEngagement": "넥스트레이드 매매체결시스템 트랙 (가온누리 구축 단계 2024.03~2025.02 → 아이티센 CTS 운영 단계 2025.03~2026.02, 동일 고객사 연속 참여)",
       "jobkoreaJobCode": "1000238"
     },
     {
@@ -166,7 +166,7 @@
           ]
         }
       ],
-      "continuousEngagement": "넥스트레이드 매매체결시스템 (2024.03~2026.02 연속 참여, 구축→운영 단계)",
+      "continuousEngagement": "넥스트레이드 매매체결시스템 트랙 (가온누리 구축 단계 2024.03~2025.02 → 아이티센 CTS 운영 단계 2025.03~2026.02, 동일 고객사 연속 참여)",
       "jobkoreaJobCode": "1000238"
     },
     {
@@ -246,7 +246,7 @@
       "teamSize": "규모 미공개 인프라 운영팀",
       "myRole": "VPN/NAC 운영 자동화 및 스위치 점검 자동화 담당",
       "workType": "SI+SM",
-      "description": "대규모 원격 근무 환경에서 신규 단말 등록과 스위치 점검의 반복 작업을 자동화하기 위해 Python과 Ansible 기반 시스템을 개발했습니다. FortiGate로 재택근무 사이트 보안을 설계하여 안전한 원격 접속 환경을 구축한 경험이 있습니다.",
+      "description": "1,000명 규모 컨택센터 원격 근무 환경에서 신규 단말 등록과 스위치 점검의 반복 작업을 자동화하기 위해 Python과 Ansible 기반 시스템을 개발했습니다. FortiGate로 재택근무 사이트 보안을 설계하여 안전한 원격 접속 환경을 구축한 경험이 있습니다.",
       "wantedSummary": "대규모 원격 근무 환경의 반복 작업을 자동화 시스템으로 전환한 경험",
       "projects": [
         {

--- a/packages/data/resumes/master/resume_data_en.json
+++ b/packages/data/resumes/master/resume_data_en.json
@@ -44,7 +44,7 @@
       "Observability",
       "Cloud Security"
     ],
-    "profileStatement": "DevSecOps/SRE engineer with 9-year career growth from OA operations into financial security automation. Started in 2017 at MT Data operating 50+ Linux servers with manual patches and firewall rules in KAI's closed network, then spent 11 months from 2018.11 reskilling on Linux fundamentals (RHCSA, CompTIA Linux+, LPIC-1, 리눅스마스터 2급). Grew through Metanet and Jointree adopting Ansible, Python, NSX-T, and Wazuh; deepened in financial infrastructure at Quantec Investment Management FSDC and Gaonnuri (FortiGate HA + FSC licensing); now operates Nextrade exchange security at ITCEN CTS using Splunk ES, n8n, FortiManager API, and Docker.",
+    "profileStatement": "DevSecOps/SRE engineer with 8 years of working experience plus 1 year Linux reskilling from OA operations into financial security automation. Started in 2017 at MT Data operating 50+ Linux servers with manual patches and firewall rules in KAI's closed network, then spent 11 months from 2018.11 reskilling on Linux fundamentals (RHCSA, CompTIA Linux+, LPIC-1, Linux Master Level 2). Grew through Metanet and Jointree adopting Ansible, Python, NSX-T, and Wazuh; deepened in financial infrastructure at Quantec Investment Management FSDC and Gaonnuri (FortiGate HA + FSC licensing); now operates Nextrade exchange security at ITCEN CTS using Splunk ES, n8n, FortiManager API, and Docker.",
     "coreCompetencies": [
       "Designed and operated high-availability security infrastructure in financial regulated environments and passed licensing audits",
       "Built SIEM detection rules and automated response systems to address delays in manual detection and response",
@@ -230,7 +230,7 @@
       "teamSize": "Infrastructure operations team (size undisclosed)",
       "myRole": "VPN/NAC automation and switch inspection automation engineer",
       "workType": "SI+SM",
-      "description": "Solved server configuration consistency and remote-access visibility for a large-scale remote work environment by building Python and Ansible automation, and operated FortiGate VPN infrastructure for new contact-center sites.",
+      "description": "Solved server configuration consistency and remote-access visibility for a 1,000-user contact-center remote-work environment by building Python and Ansible automation, and operated FortiGate VPN infrastructure for new contact-center sites.",
       "projects": [
         {
           "name": "Contact Center Remote-Work Infrastructure",

--- a/packages/data/resumes/master/resume_data_ja.json
+++ b/packages/data/resumes/master/resume_data_ja.json
@@ -43,7 +43,7 @@
       "オブザーバビリティ",
       "クラウドセキュリティ"
     ],
-    "profileStatement": "OAエンジニアから始まり9年目のDevSecOps/SREエンジニアです。2017年MT DataにてKAI(韓国航空宇宙産業)閉鎖網で50台以上のLinuxサーバの手動パッチ・ファイアウォールルール運用を経験し、2018.11から11ヶ月間RHCSA・LPIC-1などの資格でLinuxを学び直しました。Metanet、JointreeにてAnsible・Python・NSX-T・Wazuhで自動化を本格化し、Quantec FSDCで金融監督対応、Gaonnuri/Nextradeの構築でFortiGate HA・FSC認可、ITCEN CTS/Nextrade運用でSplunk ES・n8n・FortiManager API・Dockerによる自動検知・対応体制を構築しています。",
+    "profileStatement": "OAエンジニアから始まり実務8年 + Linux再学習1年のDevSecOps/SREエンジニアです。2017年MT DataにてKAI(韓国航空宇宙産業)閉鎖網で50台以上のLinuxサーバの手動パッチ・ファイアウォールルール運用を経験し、2018.11から11ヶ月間RHCSA・LPIC-1などの資格でLinuxを学び直しました。Metanet、JointreeにてAnsible・Python・NSX-T・Wazuhで自動化を本格化し、Quantec FSDCで金融監督対応、Gaonnuri/Nextradeの構築でFortiGate HA・FSC認可、ITCEN CTS/Nextrade運用でSplunk ES・n8n・FortiManager API・Dockerによる自動検知・対応体制を構築しています。",
     "coreCompetencies": [
       "金融業界の規制環境で高可用性セキュリティインフラを設計・運用し、本認可審査対応を通過した経験",
       "手動検知・対応の遅延を解決するために、SIEM 検知ルール設計と自動対応体制を構築した経験",
@@ -394,8 +394,8 @@
       "status": "active"
     },
     {
-      "name": "사무자동화산업기사",
-      "issuer": "한국산업인력공단",
+      "name": "사무자동화산업기사 (Office Automation Industrial Engineer / 韓国産業人材公団認定)",
+      "issuer": "韓国産業人材公団 (Human Resources Development Service of Korea)",
       "date": "2019.12",
       "expirationDate": null,
       "credentialId": null,
@@ -403,8 +403,8 @@
       "status": "active"
     },
     {
-      "name": "리눅스마스터 2급",
-      "issuer": "한국정보통신진흥협회",
+      "name": "リナックスマスター2級 (Linux Master Level 2 / 韓国情報通信振興協会認定)",
+      "issuer": "韓国情報通信振興協会 (Korea Association for ICT Promotion)",
       "date": "2019.01",
       "expirationDate": null,
       "credentialId": null,


### PR DESCRIPTION
Resolves Oracle's INCOMPLETE blockers: 5-platform search + critical content fixes.

## Part 1: Content fixes (6 of 8 issues)

### Critical (4 fixed)
1. **'9년차' inconsistency**: KO 'OA 엔지니어로 시작해 9년차' contradicted JobKorea live '총 7년 9개월'. Now: '8년차 (Linux 재무장 1년 포함)' across KO/EN/JA.
2. **Nextrade engagement overlap**: Gaonnuri 2024.03~2025.02 entry overlapped with continuousEngagement 2024.03~2026.02. Reworded to '구축 단계 → 운영 단계 동일 고객사 연속 참여'.
3. **EN '리눅스마스터 2급'**: replaced with 'Linux Master Level 2' in profileStatement.
4. **JA Korean cert names**: hybrid Korean+JP+EN notation (e.g., 'リナックスマスター2級 (Linux Master Level 2 / 韓国情報通信振興協会認定)').

### Medium (2 fixed, 2 deferred)
5. ✅ 'Polyglot 운영자' garbled phrase rewritten
6. ✅ Metanet '대규모' → '1,000명 규모 컨택센터'
7. ⏸️ EN 'Platform Engineer' positioning kept (intentional)
8. ⏸️ JobKorea 시스템엔지니어/소프트웨어개발자 mapping (jobkoreaJobCode 1000239 by design)

## Part 2: Multi-platform position search

| Platform | Status | Fetched | Scored ≥50 |
|----------|--------|---------|------------|
| Wanted | ✅ | 180 | 36 |
| JobKorea | ✅ | 120 | 2 |
| Saramin | ✅ | 75 | 0 (search excerpts lack description) |
| Programmers | ⚠️ empty | 0 | 0 (DOM/API maintenance needed) |
| LinkedIn | ✅ | 20 | 0 (descriptions too short) |
| **Total** | | **395** | **38** |

### Score distribution
- 🟢 Auto-apply (≥75): **1**
- 🟡 Review (60-74): 8
- ⚪ Low (50-59): 29

### 🥇 Top match
**이우소프트 Cloud Infra Engineer (Kubernetes/AWS)** — Score 76
- https://www.wanted.co.kr/wd/347834
- Matched: Kubernetes, Prometheus, Grafana, Bash, Python
- Gaps: AWS/GCP/Azure
- Apply eligibility: `blocked_auth` (Wanted credentials not in .env)

## Verification
- `npm run sync:data` ✓
- `npm run build:portfolio` ✓
- `npm test` 831/831 pass
- Production deploy: 23a31e12-1dd5-46eb-9011-35f23d2efd24

## Evidence
- `.sisyphus/evidence/2026-05-03-content-review-position-search.md` (full report)
- `.sisyphus/evidence/2026-05-03-position-search-data.json` (raw 38 jobs scored)