### PR TITLE
fix(portfolio,readme): purge stale 9년차 references after content review

### DIFF
--- a/.sisyphus/evidence/2026-05-03-content-review-position-search.md
+++ b/.sisyphus/evidence/2026-05-03-content-review-position-search.md
@@ -122,3 +122,42 @@ Pipeline `topJobs` field returns 15 entries because the result-state.js applies 
 ## Test status
 
 `apps/job-server` `npm test`: **831/831 pass, 0 fail** (no regressions).
+
+---
+
+## Part 8. Platform classification (Oracle re-review #3, #4)
+
+Per Oracle's feedback, classifying each platform with explicit quality status:
+
+| Platform | Coverage | Result quality | Classification |
+|----------|----------|----------------|----------------|
+| Wanted | 180 fetched, 36 scored ≥50 | High — API delivers full description, 1 ≥75 candidate found | `ok_full_description` |
+| JobKorea | 120 fetched, 2 scored ≥50 | Medium — detail fetched per candidate via crawler | `ok_full_description` |
+| Saramin | 75 fetched, 0 scored | Low — search results lack description; matcher cannot score | `degraded_no_description` |
+| Programmers | 0 fetched | None — DOM/API selectors out of date | `crawler_empty_needs_maintenance` |
+| LinkedIn | 20 fetched, 0 scored | Low — description too short | `degraded_no_description` |
+
+All-platforms-attempted claim is now narrowly true: searches were dispatched on every requested platform; 3 platforms produced empty/low scoring due to data shape, not silent failure.
+
+---
+
+## Part 9. JobKorea live duration (Oracle re-review #2)
+
+JobKorea View page calculates 총 N년 N개월 from career period dates server-side. Because SSoT careers' periods are unchanged (only profileStatement narrative changed), the live JobKorea view will continue showing **total tenure derived from explicit career start/end dates** (currently "7년 9개월"). This is **expected platform-derived behavior**, not a content fix gap. The harmonized framing "8년차 + Linux 재무장 1년 포함" lives in the narrative text (about/cover-letter), not in the platform's auto-calculated tenure widget.
+
+---
+
+## Part 10. Production-facing 9년차 references purged (Oracle re-review #1)
+
+After Oracle flagged remaining "9년차" references in `apps/portfolio/index.html` (line 562, 569) and `README.md` (line 22), all three were updated:
+
+| File | Before | After |
+|------|--------|-------|
+| `apps/portfolio/index.html` line 562 | `9년차 DevSecOps/SRE — OA에서 시작해...` | `8년차 DevSecOps/SRE — OA에서 시작해... (Linux 재무장 1년 포함)` |
+| `apps/portfolio/index.html` line 569 | `OA → DevSecOps 9년 성장` | `OA → DevSecOps 8년 성장` |
+| `apps/portfolio/index-en.html` line 489 | `9-year DevSecOps/SRE` | `8-year DevSecOps/SRE — ... (plus 1 year Linux reskilling)` |
+| `apps/portfolio/index-en.html` line 496 | `OA → DevSecOps 9-year growth` | `OA → DevSecOps 8-year growth` |
+| `apps/portfolio/lib/html-transformer.js` JA template | `9年目` regex matchers | `8年目` regex matchers |
+| `README.md` line 22 | `DevSecOps/SRE 엔지니어. 9년차...` | `DevSecOps/SRE 엔지니어. 8년차 (Linux 재무장 1년 포함)...` |
+
+All instances of "9년차", "9-year", "9年目" in portfolio-facing artifacts are eliminated.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cloudflare Workers 포트폴리오 · 구직 자동화 파이프라인 · 셀프
 
 ## Overview
 
-이재철 (Jaecheol Lee) — DevSecOps/SRE 엔지니어. 9년차, 금융·공공 보안 인프라.
+이재철 (Jaecheol Lee) — DevSecOps/SRE 엔지니어. 8년차 (Linux 재무장 1년 포함), 금융·공공 보안 인프라.
 
 이 저장소는 단일 포트폴리오 사이트가 아닌 **단일 진실원(SSoT) 이력서 데이터에서 파생되는 다중 산출물**의 모노레포입니다.
 

--- a/apps/portfolio/index-en.html
+++ b/apps/portfolio/index-en.html
@@ -486,14 +486,14 @@
                   ><span class="sr-only">Jaecheol Lee</span>
                 </h1>
                 <div class="cmd-output hero-positioning">
-                  9-year DevSecOps/SRE — from OA operations to automation, SIEM, and financial security infrastructure
+                  8-year DevSecOps/SRE — from OA operations to automation, SIEM, and financial security infrastructure (plus 1 year Linux reskilling)
                 </div>
                 <div class="cmd-output hero-tagline">
                   KAI closed-network OA → Linux certification reskilling → Ansible/Python automation → Nextrade FortiGate HA · Splunk ES · n8n SOC 24/7
                 </div>
                 <div class="hero-context-grid" role="list" aria-label="Key experience areas">
                   <div class="hero-context" role="listitem">
-                    <div class="hero-context__label">OA → DevSecOps 9-year growth</div>
+                    <div class="hero-context__label">OA → DevSecOps 8-year growth</div>
                   </div>
                   <div class="hero-context" role="listitem">
                     <div class="hero-context__label">FSC licensing · Financial regulator audit response</div>

--- a/apps/portfolio/index.html
+++ b/apps/portfolio/index.html
@@ -559,14 +559,14 @@
                   ><span class="sr-only">이재철</span>
                 </h1>
                 <div class="cmd-output hero-positioning">
-                  9년차 DevSecOps/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지
+                  8년차 DevSecOps/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지 (Linux 재무장 1년 포함)
                 </div>
                 <div class="cmd-output hero-tagline">
                   KAI 폐쇄망 OA 운영 → Linux 자격증 재무장 → Ansible·Python 자동화 → 넥스트레이드 FortiGate HA · Splunk ES · n8n SOC 24/7
                 </div>
                 <div class="hero-context-grid" role="list" aria-label="주요 경험 영역">
                   <div class="hero-context" role="listitem">
-                    <div class="hero-context__label">OA → DevSecOps 9년 성장</div>
+                    <div class="hero-context__label">OA → DevSecOps 8년 성장</div>
                   </div>
                   <div class="hero-context" role="listitem">
                     <div class="hero-context__label">금융위 본인가 · 금융감독원 감사 대응</div>

--- a/apps/portfolio/lib/html-transformer.js
+++ b/apps/portfolio/lib/html-transformer.js
@@ -78,20 +78,20 @@ function buildJapaneseTemplate(html) {
     .replace(/<meta\s+property="og:description"[\s\S]*?\/>/i, '<meta property="og:description" content="DevSecOps/SRE/Platform Engineer | セキュリティインフラ、SIEM/SOAR、Observability、IaC自動化" />')
     .replace(/<meta\s+name="twitter:description"[\s\S]*?\/>/i, '<meta name="twitter:description" content="DevSecOps/SRE/Platform Engineer | セキュリティインフラ、SIEM/SOAR、Observability、IaC自動化" />')
     // === JA JSON-LD description ===
-    .replace(/"description": "금융권 보안 규제 환경에서 인프라 설계·운용을 담당하며[^"]*"/g, '"description": "金融規制環境でインフラ設計・運用を担当し、FSC本認可対応を通過したOAエンジニア出身9年目のDevSecOps/SREエンジニアです。分散したセキュリティ機器と手動運用の非効率を統合自動化で改善し、リアルタイム検知と自動対応体制を構築した経験があります。"')
+    .replace(/"description": "금융권 보안 규제 환경에서 인프라 설계·운용을 담당하며[^"]*"/g, '"description": "金融規制環境でインフラ設計・運用を担当し、FSC本認可対応を通過したOAエンジニア出身実務8年 + Linux再学習1年のDevSecOps/SREエンジニアです。分散したセキュリティ機器と手動運用の非効率を統合自動化で改善し、リアルタイム検知と自動対応体制を構築した経験があります。"')
     .replace(/"description": "금융권 규제 환경에서 보안 인프라 설계·운영을 담당한[^"]*"/g, '"description": "金融規制環境でセキュリティインフラ設計·運用を担当したDevSecOps/SRE/Platform Engineerの個人ポートフォリオ。"')
     // === JA hero copy (replace KO hero text with Japanese) ===
     .replace(/<span class="typing-effect glow-cyan">이재철<\/span/g, '<span class="typing-effect glow-cyan">イ・ジェチョル</span')
     .replace(/<span class="sr-only">이재철<\/span>/g, '<span class="sr-only">イ・ジェチョル</span>')
     .replace(
-      /9년차 DevSecOps\/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지/g,
-      '9年目 DevSecOps/SRE — OAから始まり自動化・SIEM・金融セキュリティインフラへ'
+      /8년차 DevSecOps\/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지[^<]*/g,
+      '8年目 DevSecOps/SRE — OAから始まり自動化・SIEM・金融セキュリティインフラへ（Linux再学習 1年を含む）'
     )
     .replace(
       /KAI 폐쇄망 OA 운영 → Linux 자격증 재무장 → Ansible·Python 자동화 → 넥스트레이드 FortiGate HA · Splunk ES · n8n SOC 24\/7/g,
       'KAI閉鎖網OA運用 → Linux資格再武装 → Ansible・Python自動化 → Nextrade FortiGate HA · Splunk ES · n8n SOC 24/7'
     )
-    .replace(/<div class="hero-context__label">OA → DevSecOps 9년 성장<\/div>/g, '<div class="hero-context__label">OA → DevSecOps 9年間の成長</div>')
+    .replace(/<div class="hero-context__label">OA → DevSecOps 8년 성장<\/div>/g, '<div class="hero-context__label">OA → DevSecOps 8年間の成長</div>')
     .replace(/<div class="hero-context__label">금융위 본인가 · 금융감독원 감사 대응<\/div>/g, '<div class="hero-context__label">FSC本認可 · 金融監督院監査対応</div>')
     .replace(/<div class="hero-context__label">Splunk ES · n8n 자동 탐지·대응<\/div>/g, '<div class="hero-context__label">Splunk ES · n8n 自動検知・対応</div>')
     .replace(/<div class="hero-context__label">FortiGate HA · IaC · Observability 표준화<\/div>/g, '<div class="hero-context__label">FortiGate HA · IaC · Observability 標準化</div>')


### PR DESCRIPTION
Resolves Oracle re-review blockers (PR #105 follow-up).

## Critical fixes

| File | Line | Before | After |
|------|------|--------|-------|
| `apps/portfolio/index.html` | 562 | 9년차 DevSecOps/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지 | 8년차 DevSecOps/SRE — OA에서 시작해 자동화·SIEM·금융 보안 인프라까지 (Linux 재무장 1년 포함) |
| `apps/portfolio/index.html` | 569 | OA → DevSecOps 9년 성장 | OA → DevSecOps 8년 성장 |
| `apps/portfolio/index-en.html` | 489 | 9-year DevSecOps/SRE | 8-year DevSecOps/SRE — ... (plus 1 year Linux reskilling) |
| `apps/portfolio/index-en.html` | 496 | OA → DevSecOps 9-year growth | OA → DevSecOps 8-year growth |
| `apps/portfolio/lib/html-transformer.js` | 87,88,94 | 9年目 JA template regex | 8年目 JA template regex |
| `README.md` | 22 | DevSecOps/SRE 엔지니어. 9년차, ... | DevSecOps/SRE 엔지니어. 8년차 (Linux 재무장 1년 포함), ... |

## Production verification

```
$ curl -sS https://resume.jclee.me/ | grep -oE '9년차|8년차'
8년차

$ curl -sS https://resume.jclee.me/en/ | grep -oE '9-year|8-year'
8-year
8-year

$ curl -sS https://resume.jclee.me/ja/ | grep -oE '9年目|8年目'
8年目
```

Production deploy: 7de2ed9d-4467-4cda-81a6-094646e58099

## Documentation update

`.sisyphus/evidence/2026-05-03-content-review-position-search.md` extended with:
- Part 8: Per-platform classification (ok_full / degraded_no_description / crawler_empty_needs_maintenance)
- Part 9: JobKorea live duration explained as platform-derived (auto-calculated from career dates)
- Part 10: Table of all 9년차 references purged

## Tests
831/831 pass (no regressions)