### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/branch-to-pr.yml
+++ b/.github/workflows/branch-to-pr.yml
@@ -1,0 +1,133 @@
+name: Branch to Draft PR
+
+# When a feat/* fix/* hotfix/* docs/* refactor/* perf/* test/* chore/*
+# ci/* security/* build/* style/* revert/* branch is pushed and no
+# open PR exists targeting the default branch, open a draft PR.
+# Skip if author is jclee-bot itself (avoids recursion).
+
+on:
+  push:
+    branches:
+      - 'feat/**'
+      - 'fix/**'
+      - 'hotfix/**'
+      - 'docs/**'
+      - 'refactor/**'
+      - 'perf/**'
+      - 'test/**'
+      - 'chore/**'
+      - 'ci/**'
+      - 'security/**'
+      - 'build/**'
+      - 'style/**'
+      - 'revert/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Source branch
+        required: true
+        type: string
+      base:
+        description: Base branch
+        required: false
+        type: string
+        default: master
+      dry_run:
+        description: Skip PR creation
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: branch-to-pr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  open-draft-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip pushes from jclee-bot itself or from automated branch creation.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pusher.name != 'jclee-bot' &&
+       github.event.pusher.name != 'github-actions[bot]')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute PR metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            BRANCH="${{ inputs.branch }}"
+            BASE="${{ inputs.base }}"
+          else
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            BASE="${{ github.event.repository.default_branch }}"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          # Idempotency: skip if a PR already exists.
+          EXISTING=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" --base "$BASE" \
+            --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #$EXISTING already exists for $BRANCH -> $BASE"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Extract issue number from branch (pattern: <type>/issue-N-slug).
+          ISSUE_NUM=$(echo "$BRANCH" | sed -nE 's|^[^/]+/issue-([0-9]+)-.*|\1|p')
+          echo "issue_number=$ISSUE_NUM" >> "$GITHUB_OUTPUT"
+          # Last commit summary as default title.
+          LAST_COMMIT=$(git log -1 --pretty=format:%s "origin/$BRANCH" 2>/dev/null || git log -1 --pretty=format:%s)
+          echo "title=$LAST_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR
+        if: steps.meta.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          BASE: ${{ steps.meta.outputs.base }}
+          ISSUE_NUM: ${{ steps.meta.outputs.issue_number }}
+          TITLE: ${{ steps.meta.outputs.title }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # Build PR body.
+          BODY="## 변경사항"$'\n\n'"<!-- 자동으로 생성된 draft PR입니다. 마크다운으로 변경 내용을 설명해주세요. -->"$'\n\n'
+          if [ -n "$ISSUE_NUM" ]; then
+            BODY="${BODY}Closes #${ISSUE_NUM}"$'\n\n'
+          fi
+          # Append commit log range vs base branch.
+          BODY="${BODY}### 커밋 목록"$'\n'
+          # shellcheck disable=SC2129
+          {
+            git log --pretty=format:'- %s (%h)' "origin/${BASE}..origin/${BRANCH}" 2>/dev/null \
+              || git log --pretty=format:'- %s (%h)' -n 10 "origin/${BRANCH}"
+          } > /tmp/commits.txt || true
+          BODY="${BODY}$(cat /tmp/commits.txt)"
+          BODY="${BODY}"$'\n\n'"> Automated by jclee-bot (branch-to-pr.yml)"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would open draft PR $BRANCH -> $BASE"
+            echo "title: $TITLE"
+            echo "body: $BODY"
+            exit 0
+          fi
+          # Create the draft PR.
+          gh pr create --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" --base "$BASE" \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --draft \
+            || echo "::warning::PR creation failed (likely already exists or no diff yet)"

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -1,0 +1,156 @@
+name: CI Failure Issues
+
+# When Sanity or Auto Deploy Workflows fails on master, create a
+# deduplicated issue. If an open issue already exists for the same
+# (workflow, sha) pair, append a comment instead of creating a duplicate.
+#
+# Replaces the duplicate-prone direct `gh issue create` step in
+# auto-deploy.yml that produced issues #18 and #29.
+
+on:
+  workflow_run:
+    workflows: ["Sanity", "Auto Deploy Workflows"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      workflow_name:
+        description: Workflow name
+        required: true
+        type: string
+      head_sha:
+        description: Commit SHA
+        required: true
+        type: string
+      run_id:
+        description: Run ID (0 for synthetic)
+        required: true
+        type: string
+      conclusion:
+        description: Conclusion (failure or success)
+        required: true
+        type: string
+        default: failure
+      dry_run:
+        description: Skip actual issue ops
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: ci-failure-issues-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Trigger only on FAILURE conclusion (success → close stale below).
+    # workflow_run only fires on default branch by default, which is what we want.
+    steps:
+      - name: Compute event
+        id: ev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            WF_NAME="${{ inputs.workflow_name }}"
+            HEAD_SHA="${{ inputs.head_sha }}"
+            RUN_ID="${{ inputs.run_id }}"
+            CONCLUSION="${{ inputs.conclusion }}"
+          else
+            WF_NAME='${{ github.event.workflow_run.name }}'
+            HEAD_SHA='${{ github.event.workflow_run.head_sha }}'
+            RUN_ID='${{ github.event.workflow_run.id }}'
+            CONCLUSION='${{ github.event.workflow_run.conclusion }}'
+          fi
+          {
+            echo "wf_name=$WF_NAME"
+            echo "head_sha=$HEAD_SHA"
+            echo "run_id=$RUN_ID"
+            echo "conclusion=$CONCLUSION"
+            echo "short_sha=${HEAD_SHA:0:8}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: On success, close any open ci-failure issue for this workflow
+        if: steps.ev.outputs.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WF_NAME: ${{ steps.ev.outputs.wf_name }}
+          HEAD_SHA: ${{ steps.ev.outputs.head_sha }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # The title pattern is stable so we can dedupe and recover.
+          TITLE_PREFIX="[ci] $WF_NAME failed at"
+          OPEN_ISSUES=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --label ci-failure --search "in:title \"$TITLE_PREFIX\"" \
+            --json number,title --jq '.[] | .number' 2>/dev/null || true)
+          if [ -z "$OPEN_ISSUES" ]; then
+            echo "::notice::No open ci-failure issue to close for $WF_NAME"
+            exit 0
+          fi
+          for N in $OPEN_ISSUES; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::DRY-RUN: would close stale ci-failure issue #$N"
+              continue
+            fi
+            gh issue close "$N" --repo "$GITHUB_REPOSITORY" \
+              --comment "Resolved by a successful $WF_NAME run on $HEAD_SHA. Auto-closed by jclee-bot." \
+              --reason completed \
+              || echo "::warning::failed to close #$N; continuing"
+          done
+
+      - name: Ensure label exists
+        if: steps.ev.outputs.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create ci-failure --color B60205 --description "Auto-managed by ci-failure-issues.yml" 2>/dev/null || true
+          gh label create automated --color BFD4F2 --description "Auto-managed by jclee-bot" 2>/dev/null || true
+
+      - name: Find or create issue for failure
+        if: steps.ev.outputs.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WF_NAME: ${{ steps.ev.outputs.wf_name }}
+          HEAD_SHA: ${{ steps.ev.outputs.head_sha }}
+          SHORT_SHA: ${{ steps.ev.outputs.short_sha }}
+          RUN_ID: ${{ steps.ev.outputs.run_id }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          TITLE="[ci] $WF_NAME failed at $SHORT_SHA"
+          # Idempotency: search for an open issue with the SAME title.
+          # Compare exact title rather than substring to avoid false matches.
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --label ci-failure \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" 2>/dev/null | head -1 || true)
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RUN_ID"
+          BODY="## CI Failure"$'\n\n'"- **Workflow:** $WF_NAME"$'\n'"- **Commit:** $HEAD_SHA"$'\n'"- **Run:** $RUN_URL"$'\n\n'"### Action Required"$'\n'"Inspect the failed run and either fix the underlying problem or close this issue if the failure was transient."$'\n\n'"> Auto-managed by jclee-bot (ci-failure-issues.yml)"
+          if [ -n "$EXISTING" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::DRY-RUN: would comment on existing issue #$EXISTING"
+              exit 0
+            fi
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Another failure for the same workflow+sha. Run: $RUN_URL" \
+              || echo "::warning::failed to add dedup comment; continuing"
+            echo "::notice::Recorded duplicate failure on existing issue #$EXISTING"
+          else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::DRY-RUN: would create new issue: $TITLE"
+              exit 0
+            fi
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label ci-failure,automated \
+              || echo "::warning::failed to create ci-failure issue; non-fatal"
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,15 +41,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:python'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -41,14 +41,19 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
-        run: gh pr review --approve "$PR_URL" --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)"
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)" \
+          || echo "::warning::approve failed for $PR_URL (already approved or insufficient permissions); continuing"
 
       - name: Enable auto-merge for safe updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          gh pr merge --auto --squash "$PR_URL" \
+          || echo "::warning::auto-merge enable failed for $PR_URL (allow_auto_merge disabled or branch protection missing); continuing"
 
       - name: Flag major updates for manual review
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
@@ -56,7 +61,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
-        run: gh pr comment "$PR_URL" --body "Major version bump for $DEP_NAMES - manual review required."
+        run: |
+          gh pr comment "$PR_URL" \
+            --body "Major version bump for $DEP_NAMES - manual review required." \
+          || echo "::warning::failed to post manual-review comment for $PR_URL; continuing"
 
       - name: Flag unknown update type for manual review
         if: ${{ steps.meta.outputs.update-type == '' || steps.meta.outputs.update-type == 'null' }}
@@ -65,4 +73,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
-        run: gh pr comment "$PR_URL" --body "Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required."
+        run: |
+          gh pr comment "$PR_URL" \
+            --body "Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required." \
+          || echo "::warning::failed to post unknown-update-type comment for $PR_URL; continuing"

--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -1,0 +1,146 @@
+name: Issue Backfill
+
+# Picks up pre-existing open issues that were created BEFORE the
+# git-flow automation was deployed and would otherwise never get a
+# branch. For each candidate it adds the `in-progress` label, which
+# triggers issue-to-branch.yml in the normal way.
+#
+# Selection rules (every condition must hold):
+#   - state: open
+#   - no associated PR (closed or open) referencing this issue
+#   - none of the skip labels: wontfix, duplicate, invalid, bot-review,
+#     ci-failure, automated, dependencies
+#   - none of the trigger labels: in-progress (already triggered)
+#   - last-update age >= min_age_days
+#
+# Defaults to dry-run; only the explicit `dry_run=false` dispatch
+# actually mutates labels.
+
+on:
+  schedule:
+    # Daily 09:00 UTC (18:00 KST). Manual dispatch is the primary path.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: If true, only report candidates; do not add labels
+        required: false
+        type: boolean
+        default: true
+      min_age_days:
+        description: Pick only issues last updated this many days ago
+        required: false
+        default: "5"
+      max_picks:
+        description: Cap on how many issues to label per run (per repo)
+        required: false
+        default: "3"
+      label:
+        description: Label to add (default in-progress = triggers issue-to-branch.yml)
+        required: false
+        default: in-progress
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: issue-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Pick and label candidates
+        env:
+          # Use a fine-grained PAT (secrets.GH_PAT) when available so the
+          # subsequent `labeled` event re-fires downstream workflows like
+          # issue-to-branch.yml. With the default GITHUB_TOKEN the event
+          # is suppressed to prevent recursive cascades, which here means
+          # the backfill silently completes without triggering branch
+          # creation.
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run == false && 'false' || 'true' }}
+          MIN_AGE_DAYS: ${{ inputs.min_age_days || '5' }}
+          MAX_PICKS: ${{ inputs.max_picks || '3' }}
+          LABEL: ${{ inputs.label || 'in-progress' }}
+        run: |
+          set -eu
+          REPO=$GITHUB_REPOSITORY
+          NOW=$(date -u +%s)
+          THRESHOLD=$((NOW - MIN_AGE_DAYS * 86400))
+          SKIP_LABELS="wontfix duplicate invalid bot-review ci-failure automated dependencies"
+          # Pre-fetch open issues; up to 100 per page is fine for our repos.
+          gh issue list --repo "$REPO" --state open --limit 100 \
+            --json number,title,updatedAt,labels,assignees \
+            > /tmp/issues.json
+          PICKED=0
+          {
+            echo "## Issue Backfill Candidates ($REPO)"
+            echo
+            echo "| # | Title | Age | Action |"
+            echo "|---|-------|-----|--------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for n in $(jq -r '.[].number' /tmp/issues.json); do
+            ISSUE=$(jq -c --arg n "$n" '.[] | select(.number == ($n | tonumber))' /tmp/issues.json)
+            UPDATED=$(echo "$ISSUE" | jq -r '.updatedAt')
+            UPDATED_TS=$(date -u -d "$UPDATED" +%s)
+            AGE_DAYS=$(((NOW - UPDATED_TS) / 86400))
+            TITLE=$(echo "$ISSUE" | jq -r '.title' | tr '|' '/' | head -c 60)
+            # Filter rules.
+            if [ "$UPDATED_TS" -gt "$THRESHOLD" ]; then
+              echo "| #$n | $TITLE | ${AGE_DAYS}d | skip: too fresh |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            LABEL_NAMES=$(echo "$ISSUE" | jq -r '.labels[].name' | tr '\n' ' ')
+            SKIP=0
+            for sl in $SKIP_LABELS; do
+              case " $LABEL_NAMES " in
+                *" $sl "*) SKIP=1; break ;;
+              esac
+            done
+            if [ "$SKIP" = "1" ]; then
+              echo "| #$n | $TITLE | ${AGE_DAYS}d | skip: has skip-label |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            case " $LABEL_NAMES " in
+              *" $LABEL "*)
+                echo "| #$n | $TITLE | ${AGE_DAYS}d | skip: already labeled |" >> "$GITHUB_STEP_SUMMARY"
+                continue
+                ;;
+            esac
+            # Skip if a PR already references this issue. gh issue list's
+            # JSON view does not expose closedByPullRequestsReferences, so
+            # query the timeline events for cross-referenced PRs instead.
+            HAS_PR=$(gh api "repos/$REPO/issues/$n/timeline" --paginate \
+                       --jq '[.[] | select(.event == "cross-referenced" and .source.type == "issue" and .source.issue.pull_request != null)] | length' \
+                       2>/dev/null || echo 0)
+            if [ "${HAS_PR:-0}" != "0" ]; then
+              echo "| #$n | $TITLE | ${AGE_DAYS}d | skip: PR linked |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            # Cap.
+            if [ "$PICKED" -ge "$MAX_PICKS" ]; then
+              echo "| #$n | $TITLE | ${AGE_DAYS}d | skip: max picks reached |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "| #$n | $TITLE | ${AGE_DAYS}d | DRY-RUN would label |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              if gh issue edit "$n" --repo "$REPO" --add-label "$LABEL" >/dev/null 2>&1; then
+                echo "| #$n | $TITLE | ${AGE_DAYS}d | labeled :white_check_mark: |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| #$n | $TITLE | ${AGE_DAYS}d | label-add failed :x: |" >> "$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+            fi
+            PICKED=$((PICKED + 1))
+          done
+          {
+            echo
+            echo "Picked: $PICKED (max $MAX_PICKS)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Picked $PICKED candidates."

--- a/.github/workflows/issue-to-branch.yml
+++ b/.github/workflows/issue-to-branch.yml
@@ -1,0 +1,128 @@
+name: Issue to Branch
+
+# When an issue gets the `in-progress` label or is assigned, create a
+# branch named <type>/issue-<N>-<slug-of-title> from the default branch.
+# Type derived from issue labels (bug→fix, enhancement→feat, etc.).
+# Idempotent: skip if branch already exists.
+
+on:
+  issues:
+    types: [labeled, assigned]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to create branch for
+        required: true
+        type: string
+      dry_run:
+        description: Skip actual branch creation
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: issue-to-branch-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Trigger only when the label is `in-progress` OR the issue gets assigned to a human (not the bot itself).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'in-progress') ||
+      (github.event.action == 'assigned' && github.event.assignee.login != 'jclee-bot')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute branch metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: |
+          set -eu
+          DATA=$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,title,labels,state)
+          STATE=$(echo "$DATA" | jq -r '.state')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::warning::Issue #$ISSUE_NUMBER is $STATE; skipping branch creation."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TITLE=$(echo "$DATA" | jq -r '.title')
+          LABELS=$(echo "$DATA" | jq -r '.labels[].name' | tr '\n' ' ')
+          # Derive branch type from labels in priority order.
+          TYPE="chore"
+          for label in $LABELS; do
+            case "$label" in
+              bug|fix) TYPE="fix"; break ;;
+              enhancement|feature|feat) TYPE="feat"; break ;;
+              docs|documentation) TYPE="docs"; break ;;
+              security) TYPE="security"; break ;;
+              performance|perf) TYPE="perf"; break ;;
+              refactor) TYPE="refactor"; break ;;
+              tests|test) TYPE="test"; break ;;
+              dependencies) TYPE="chore"; break ;;
+            esac
+          done
+          # Slugify title: lowercase, replace non-alphanum with -, collapse, trim, max 40 chars.
+          SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-40 \
+            | sed 's/-$//')
+          # Empty-slug fallback for emoji-only or non-Latin titles.
+          if [ -z "$SLUG" ]; then SLUG="untitled"; fi
+          BRANCH="${TYPE}/issue-${ISSUE_NUMBER}-${SLUG}"
+          {
+            echo "branch=$BRANCH"
+            echo "type=$TYPE"
+            echo "issue_number=$ISSUE_NUMBER"
+            echo "title=$TITLE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Computed branch: $BRANCH"
+
+      - name: Create branch
+        if: steps.meta.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # Idempotency: skip if branch already exists.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::notice::Branch $BRANCH already exists; nothing to do."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would create $BRANCH from $DEFAULT_BRANCH"
+            exit 0
+          fi
+          DEFAULT_SHA=$(git rev-parse "origin/$DEFAULT_BRANCH")
+          gh api -X POST \
+            "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f "ref=refs/heads/$BRANCH" \
+            -f "sha=$DEFAULT_SHA" \
+            || { echo "::warning::branch creation API call failed"; exit 0; }
+          echo "Created $BRANCH at $DEFAULT_SHA"
+
+      - name: Comment on issue
+        if: steps.meta.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.meta.outputs.issue_number }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Branch \`$BRANCH\` created. Push commits to that branch and a draft PR will open automatically." \
+            || echo "::warning::comment failed; non-fatal"

--- a/.github/workflows/merged-pr-cleanup.yml
+++ b/.github/workflows/merged-pr-cleanup.yml
@@ -1,0 +1,142 @@
+name: Merged PR Cleanup
+
+# When a PR is merged:
+#   - close any linked issues (Closes/Fixes/Resolves keyword OR
+#     branch-name issue-N pattern)
+#   - delete the source branch (unless it's master/main/release/*)
+# Best-effort: missing branch / closed issue → warning, not failure.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number
+        required: true
+        type: string
+      dry_run:
+        description: Skip actual deletes/closes
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: merged-pr-cleanup-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == true)
+    steps:
+      - name: Gather PR data
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -eu
+          DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,headRefName,headRepository,baseRefName,body,state,title)
+          STATE=$(echo "$DATA" | jq -r '.state')
+          if [ "$STATE" != "MERGED" ]; then
+            echo "::notice::PR #$PR_NUMBER is $STATE; skipping cleanup."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HEAD_REF=$(echo "$DATA" | jq -r '.headRefName')
+          HEAD_REPO=$(echo "$DATA" | jq -r '.headRepository.name // empty')
+          BASE_REF=$(echo "$DATA" | jq -r '.baseRefName')
+          BODY=$(echo "$DATA" | jq -r '.body // ""')
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "head_ref=$HEAD_REF"
+            echo "head_repo=$HEAD_REPO"
+            echo "base_ref=$BASE_REF"
+          } >> "$GITHUB_OUTPUT"
+          # Persist body to a file (multi-line, safer than $GITHUB_OUTPUT).
+          printf '%s' "$BODY" > /tmp/pr_body.txt
+
+      - name: Close linked issues
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # 1) Keywords in body — GitHub already auto-closes these on the
+          #    *origin* repo when the PR merges to default branch, but we
+          #    do an explicit pass to handle non-default-base merges.
+          ISSUES=$(grep -oiE '(closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)[[:space:]]+#[0-9]+' /tmp/pr_body.txt 2>/dev/null \
+            | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
+          # 2) Branch-name fallback: type/issue-N-slug
+          BRANCH_ISSUE=$(echo "$HEAD_REF" | sed -nE 's|^[^/]+/issue-([0-9]+)-.*|\1|p')
+          if [ -n "$BRANCH_ISSUE" ]; then
+            ISSUES="$ISSUES $BRANCH_ISSUE"
+          fi
+          ISSUES=$(echo "$ISSUES" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+          if [ -z "$ISSUES" ]; then
+            echo "::notice::No linked issues found for PR #$PR_NUMBER"
+            exit 0
+          fi
+          for I in $ISSUES; do
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice::DRY-RUN: would close issue #$I"
+              continue
+            fi
+            CURRENT_STATE=$(gh issue view "$I" --repo "$GITHUB_REPOSITORY" --json state -q .state 2>/dev/null || echo MISSING)
+            if [ "$CURRENT_STATE" = "OPEN" ]; then
+              gh issue close "$I" --repo "$GITHUB_REPOSITORY" \
+                --comment "Closed automatically by merged PR #$PR_NUMBER (branch \`$HEAD_REF\`)." \
+                --reason completed \
+                || echo "::warning::failed to close issue #$I; continuing"
+            else
+              echo "::notice::Issue #$I state=$CURRENT_STATE; not changing."
+            fi
+          done
+
+      - name: Delete source branch
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # Skip protected branches.
+          case "$HEAD_REF" in
+            master|main|develop|release|release/*)
+              echo "::notice::Refusing to delete protected branch: $HEAD_REF"
+              exit 0 ;;
+          esac
+          # Skip fork branches (head repo != base repo).
+          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "${GITHUB_REPOSITORY##*/}" ]; then
+            echo "::notice::Branch lives on fork ($HEAD_REPO); skipping delete."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would delete branch $HEAD_REF"
+            exit 0
+          fi
+          # GitHub may have already auto-deleted on merge — treat 404 as success.
+          if gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/heads/$HEAD_REF" 2>/tmp/del_err; then
+            echo "Deleted $HEAD_REF"
+          else
+            if grep -q "Reference does not exist" /tmp/del_err 2>/dev/null; then
+              echo "::notice::Branch $HEAD_REF already deleted by GitHub"
+            else
+              echo "::warning::failed to delete branch $HEAD_REF: $(cat /tmp/del_err)"
+            fi
+          fi

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,0 +1,119 @@
+name: PR Auto-Merge (human-authored)
+
+# Enables auto-merge (squash) on a PR when:
+#   - the author is human (NOT *[bot] — dependabot has its own workflow)
+#   - the PR is not draft
+#   - mergeStateStatus eventually reaches CLEAN
+#   - all required checks pass (handled by branch protection, not us)
+#
+# We never use --admin and never bypass branch protection.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number
+        required: true
+        type: string
+      dry_run:
+        description: Skip the actual auto-merge enable
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-auto-merge-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Trigger on either:
+    #   1. an APPROVED review on a non-draft, non-bot PR
+    #   2. an explicit `auto-merge` label being added
+    #   3. manual dispatch
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved' &&
+       github.event.pull_request.draft == false &&
+       !endsWith(github.event.pull_request.user.login, '[bot]')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'auto-merge' &&
+       github.event.pull_request.draft == false)
+    steps:
+      - name: Determine PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -eu
+          DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,state,isDraft,mergeStateStatus,author,url,reviews,reviewDecision,statusCheckRollup)
+          STATE=$(echo "$DATA" | jq -r '.state')
+          IS_DRAFT=$(echo "$DATA" | jq -r '.isDraft')
+          AUTHOR=$(echo "$DATA" | jq -r '.author.login')
+          REVIEW_DECISION=$(echo "$DATA" | jq -r '.reviewDecision // "NONE"')
+          URL=$(echo "$DATA" | jq -r '.url')
+          {
+            echo "number=$PR_NUMBER"
+            echo "state=$STATE"
+            echo "is_draft=$IS_DRAFT"
+            echo "author=$AUTHOR"
+            echo "review_decision=$REVIEW_DECISION"
+            echo "url=$URL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Guardrails
+        env:
+          STATE: ${{ steps.pr.outputs.state }}
+          IS_DRAFT: ${{ steps.pr.outputs.is_draft }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+          REVIEW_DECISION: ${{ steps.pr.outputs.review_decision }}
+        run: |
+          set -eu
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::notice::PR is $STATE; skipping."
+            echo "skip=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "::notice::PR is draft; skipping."
+            echo "skip=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          case "$AUTHOR" in
+            *\[bot\]) echo "::notice::PR by bot $AUTHOR — handled elsewhere; skipping."; echo "skip=true" >> "$GITHUB_ENV"; exit 0 ;;
+          esac
+          # Either an APPROVED review must exist, or the user explicitly
+          # labeled the PR with `auto-merge`. The `if:` guard already
+          # filters by event, so reaching this step is enough.
+          echo "Guardrails passed for PR $AUTHOR (decision=$REVIEW_DECISION)"
+
+      - name: Enable auto-merge
+        if: env.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would call gh pr merge --auto --squash $PR_URL"
+            exit 0
+          fi
+          # GitHub auto-merge only fires once all required status checks pass
+          # and the merge box is green. We just enable it; we never bypass.
+          gh pr merge --auto --squash "$PR_URL" \
+            || echo "::warning::auto-merge enable failed (allow_auto_merge disabled, branch protection mismatch, or PR already merged); not retrying"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -137,13 +137,68 @@ jobs:
           print("preflight ok: github.user_token configured")
           PY
 
-          # Run the review and capture both pr-agent's exit code and its log output.
-          # pr-agent's CLI exits 0 even on fatal provider errors (silent-success), so we
-          # additionally grep the captured log for known fatal patterns and fail the job.
-          set +e
-          .venv/bin/python -m pr_agent.cli --pr_url "$PR_URL" review 2>&1 | tee /tmp/pr-agent.log
-          status=${PIPESTATUS[0]}
-          set -e
+          # Dynamic command selection based on PR characteristics.
+          # Decision order (first match wins):
+          #   1. Dependabot/bot author     -> review
+          #   2. Docs-only diff            -> describe
+          #   3. feat:/fix:/refactor: title-> describe review improve agentic_review
+          #   4. < 50 LOC                  -> review
+          #   5. > 1000 LOC                -> describe review
+          #   6. default                   -> describe review improve agentic_review
+          PR_NUM=${{ github.event.pull_request.number }}
+          PR_DATA=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" \
+            --json additions,deletions,files,title,author 2>/dev/null || echo '{}')
+          ADDS=$(echo "$PR_DATA" | jq -r '.additions // 0')
+          DELS=$(echo "$PR_DATA" | jq -r '.deletions // 0')
+          LOC=$((ADDS + DELS))
+          AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // ""')
+          TITLE=$(echo "$PR_DATA" | jq -r '.title // ""')
+          # Treat the diff as docs-only when EVERY changed file matches the docs allowlist.
+          NON_DOCS=$(echo "$PR_DATA" | jq -r '.files[]?.path // empty' \
+            | grep -vE '\.(md|rst|txt|adoc)$|^docs/|^README|^LICENSE|^NOTICE|^CONTRIBUTING|^\.github/(ISSUE|PULL_REQUEST)' || true)
+          DOCS_ONLY=false
+          if [ -n "$(echo "$PR_DATA" | jq -r '.files[]?.path' 2>/dev/null)" ] && [ -z "$NON_DOCS" ]; then
+            DOCS_ONLY=true
+          fi
+          if echo "$AUTHOR" | grep -qE '\[bot\]$'; then
+            CMDS="review"
+            REASON="bot author"
+          elif [ "$DOCS_ONLY" = "true" ]; then
+            CMDS="describe"
+            REASON="docs-only diff"
+          elif echo "$TITLE" | grep -qE '^(feat|fix|refactor)(\([a-z0-9_/-]+\))?!?:'; then
+            CMDS="describe review improve agentic_review"
+            REASON="feat/fix/refactor PR"
+          elif [ "$LOC" -lt 50 ]; then
+            CMDS="review"
+            REASON="small PR (<50 LOC)"
+          elif [ "$LOC" -gt 1000 ]; then
+            CMDS="describe review"
+            REASON="large PR (>1000 LOC)"
+          else
+            CMDS="describe review improve agentic_review"
+            REASON="default"
+          fi
+          echo "::notice::PR #$PR_NUM (LOC=$LOC, author=$AUTHOR, title=$TITLE)"
+          echo "::notice::Selected commands: $CMDS  ($REASON)"
+
+          # Run the selected commands and capture pr-agent's combined output.
+          # pr-agent's CLI exits 0 even on fatal provider errors (silent-success),
+          # so we additionally grep the captured log for known fatal patterns.
+          : > /tmp/pr-agent.log
+          status=0
+          for cmd in $CMDS; do
+            echo "--- running pr-agent $cmd ---" | tee -a /tmp/pr-agent.log
+            set +e
+            .venv/bin/python -m pr_agent.cli --pr_url "$PR_URL" "$cmd" 2>&1 | tee -a /tmp/pr-agent.log
+            cmd_status=${PIPESTATUS[0]}
+            set -e
+            if [ "$cmd_status" -ne 0 ]; then
+              status=$cmd_status
+              echo "::error::pr-agent $cmd exited with status $cmd_status"
+              break
+            fi
+          done
 
           if [ "$status" -ne 0 ]; then
             echo "::error::pr-agent CLI exited with status $status"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,160 @@
+name: Release Publish
+
+# When a Conventional Commit is merged to master, compute the next semver
+# from the most recent v* tag, create an annotated tag, and publish a
+# GitHub Release using release-drafter's existing draft (if any).
+#
+# Bump rules (Conventional Commits):
+#   BREAKING CHANGE / footer `!` -> major
+#   feat:                        -> minor
+#   fix: / perf: / refactor:     -> patch
+#   chore:/docs:/test:/ci:/style:/build: -> no bump (skip)
+
+on:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: SHA to inspect (defaults to HEAD)
+        required: false
+        type: string
+      dry_run:
+        description: Skip the actual tag/release publish
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  bump-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (full history for tag scan)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine bump
+        id: bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          set -eu
+          SHA="${INPUT_SHA:-${GITHUB_SHA}}"
+          # Latest tag (if any).
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            PREV_VERSION="0.0.0"
+            COMMIT_RANGE="$SHA"
+          else
+            PREV_VERSION=${PREV_TAG#v}
+            COMMIT_RANGE="$PREV_TAG..$SHA"
+          fi
+          MAJOR=${PREV_VERSION%%.*}
+          MINOR_PATCH=${PREV_VERSION#*.}
+          MINOR=${MINOR_PATCH%%.*}
+          PATCH=${MINOR_PATCH#*.}
+          # Inspect every commit in the range and find the highest bump.
+          BUMP="none"
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            # BREAKING change: footer keyword OR `!` after type.
+            if echo "$line" | grep -qE '^[a-z]+(\([a-z0-9_/-]+\))?!:'; then BUMP="major"; break; fi
+            if echo "$line" | grep -qE 'BREAKING CHANGE'; then BUMP="major"; break; fi
+            if echo "$line" | grep -qE '^feat(\(.+\))?:'; then [ "$BUMP" = "major" ] || BUMP="minor"; fi
+            if echo "$line" | grep -qE '^(fix|perf|refactor)(\(.+\))?:'; then
+              [ "$BUMP" = "none" ] && BUMP="patch"
+            fi
+          done < <(git log --pretty=format:'%s%n%b' "$COMMIT_RANGE" 2>/dev/null || true)
+          if [ "$BUMP" = "none" ]; then
+            echo "::notice::No semver-bumping commits since $PREV_TAG; nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$BUMP" in
+            major) NEW="v$((MAJOR+1)).0.0" ;;
+            minor) NEW="v$MAJOR.$((MINOR+1)).0" ;;
+            patch) NEW="v$MAJOR.$MINOR.$((PATCH+1))" ;;
+          esac
+          {
+            echo "prev_tag=$PREV_TAG"
+            echo "new_tag=$NEW"
+            echo "bump=$BUMP"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Computed bump=$BUMP from $PREV_TAG to $NEW (sha=$SHA)"
+
+      - name: Create tag
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+          SHA: ${{ steps.bump.outputs.sha }}
+          BUMP: ${{ steps.bump.outputs.bump }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          # Idempotency: if tag already exists at the same SHA, skip create.
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            EXISTING_SHA=$(git rev-parse "$NEW_TAG^{}")
+            if [ "$EXISTING_SHA" = "$SHA" ]; then
+              echo "::notice::Tag $NEW_TAG already at $SHA; skipping creation."
+              exit 0
+            else
+              echo "::warning::Tag $NEW_TAG exists at $EXISTING_SHA, but we want $SHA. Refusing to move; manual intervention required."
+              exit 1
+            fi
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would create $NEW_TAG (bump=$BUMP) at $SHA"
+            exit 0
+          fi
+          gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f "ref=refs/tags/$NEW_TAG" \
+            -f "sha=$SHA" \
+            || { echo "::warning::tag create failed"; exit 1; }
+          echo "Created $NEW_TAG at $SHA (bump=$BUMP)"
+
+      - name: Publish release (using release-drafter draft if present)
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+          BUMP: ${{ steps.bump.outputs.bump }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -eu
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::DRY-RUN: would publish release $NEW_TAG"
+            exit 0
+          fi
+          # Look for an existing draft release we can promote.
+          DRAFT_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[] | select(.draft==true) | .id' 2>/dev/null | head -1 || true)
+          if [ -n "$DRAFT_ID" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$DRAFT_ID" \
+              -f "tag_name=$NEW_TAG" \
+              -f "name=$NEW_TAG" \
+              -F "draft=false" \
+              -F "prerelease=false" \
+              -F "make_latest=true" \
+              || { echo "::warning::failed to promote draft release $DRAFT_ID"; exit 1; }
+            echo "Promoted draft release -> $NEW_TAG"
+          else
+            # No draft (release-drafter not configured or hadn't run) — create.
+            gh release create "$NEW_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$NEW_TAG" \
+              --generate-notes \
+              || { echo "::warning::release create failed"; exit 1; }
+            echo "Created release $NEW_TAG with auto-generated notes"
+          fi

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create issue for broken links
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = `## 🚨 문서 링크 깨짐 감지\n\n` +
@@ -64,10 +64,8 @@ jobs:
         run: |
           markdownlint '**/*.md' \
             --ignore node_modules \
-            --ignore '**/node_modules/**' \
             --ignore .venv \
-            --ignore '**/pr-agent-upstream-README.md' \
-            --ignore 'applications/**'
+            --ignore '**/pr-agent-upstream-README.md'
 
   readme-sync-check:
     runs-on: ubuntu-latest
@@ -79,7 +77,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check README sync
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -135,7 +133,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check API documentation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Auto-label new issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -82,7 +82,7 @@ jobs:
     if: github.event_name == 'issue_comment' || (github.event_name == 'issues' && contains(fromJson('["reopened", "edited"]'), github.event.action))
     steps:
       - name: Remove stale label on activity
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue || context.payload.comment?.issue;
@@ -104,7 +104,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Generate Issue Statistics
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -13,15 +13,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
+          set -u
           PR_NUM=${{ github.event.pull_request.number }}
           REPO=${{ github.repository }}
-          LOC_DATA=$(gh pr view "$PR_NUM" --repo "$REPO" --json additions,deletions -q '.additions + .deletions')
-          echo "PR #$PR_NUM total changed lines: $LOC_DATA"
+          AUTHOR=${{ github.event.pull_request.user.login }}
+          # Bots (dependabot, renovate) regularly produce large diffs from
+          # bumping vendored deps. Their oversized-PR issues are noise and
+          # the gh pr view call below has been hitting rate limits on
+          # bot-flooded repos. Skip the size check entirely for bots.
+          if [[ "$AUTHOR" == *"[bot]" ]]; then
+            echo "::notice::Skipping size check for bot author=$AUTHOR"
+            exit 0
+          fi
+          LOC_DATA=$(gh pr view "$PR_NUM" --repo "$REPO" --json additions,deletions -q '.additions + .deletions') \
+            || { echo "::warning::gh pr view failed (likely rate limit); skipping size check"; exit 0; }
+          echo "PR #$PR_NUM (author=$AUTHOR) total changed lines: $LOC_DATA"
           if [ "$LOC_DATA" -gt 500 ]; then
             gh issue create --repo "$REPO" \
               --title "[BOT] PR #$PR_NUM exceeds 500 LOC ($LOC_DATA lines)" \
-              --body "## Large PR Detected\n\n- **PR**: #$PR_NUM\n- **Changed Lines**: $LOC_DATA\n- **Threshold**: 500\n\nThis PR exceeds the recommended maximum of 500 changed lines. Consider splitting it into smaller, focused PRs for easier review.\n\n> Automated by jclee-bot"
+              --body "## Large PR Detected\n\n- **PR**: #$PR_NUM\n- **Changed Lines**: $LOC_DATA\n- **Threshold**: 500\n\nThis PR exceeds the recommended maximum of 500 changed lines. Consider splitting it into smaller, focused PRs for easier review.\n\n> Automated by jclee-bot" \
+              || echo "::warning::Failed to create oversized-PR issue (rate limit or permissions); continuing"
           fi
 
   check-title:
@@ -30,7 +41,7 @@ jobs:
     name: Check PR Title
     steps:
       - name: Conventional Commits validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -55,7 +66,7 @@ jobs:
     name: Check Branch Name
     steps:
       - name: Branch naming validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -80,31 +91,40 @@ jobs:
     name: Check PR Description
     steps:
       - name: Description validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';
-            
-            if (body.length < 10) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `## PR 설명 부족\n\n설명이 너무 짧습니다 (최소 10자). 변경 내용을 자세히 적어주세요.\n\n> Automated by jclee-bot`
-              });
+            const author = (context.payload.pull_request.user || {}).login || '';
+            // Bots (dependabot, renovate) generate complete release-notes-style
+            // bodies that should not trigger description-quality nags.
+            if (author.endsWith('[bot]')) {
+              core.info(`Skipping description check for bot author: ${author}`);
+              return;
             }
-            
-            const hasChanges = body.toLowerCase().includes('changes') || 
-                              body.toLowerCase().includes('변경') ||
+            const tryComment = async (commentBody) => {
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: commentBody,
+                });
+              } catch (e) {
+                // Resource-not-accessible-by-integration on forks / dependabot PRs
+                // is expected; degrade to a warning so the check stays green.
+                core.warning(`Could not post description-validation comment: ${e.message}`);
+              }
+            };
+
+            if (body.length < 10) {
+              await tryComment('## PR \uc124\uba85 \ubd80\uc871\n\n\uc124\uba85\uc774 \ub108\ubb34 \uc9e7\uc2b5\ub2c8\ub2e4 (\ucd5c\uc18c 10\uc790). \ubcc0\uacbd \ub0b4\uc6a9\uc744 \uc790\uc138\ud788 \uc801\uc5b4\uc8fc\uc138\uc694.\n\n> Automated by jclee-bot');
+            }
+            const hasChanges = body.toLowerCase().includes('changes') ||
+                              body.toLowerCase().includes('\ubcc0\uacbd') ||
                               body.toLowerCase().includes('##');
-            
             if (!hasChanges) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `## PR 설명 개선 필요\n\n변경 사항(Changes/변경사항) 섹션을 추가해주세요.\n\n> Automated by jclee-bot`
-              });
+              await tryComment('## PR \uc124\uba85 \uac1c\uc120 \ud544\uc694\n\n\ubcc0\uacbd \uc0ac\ud56d(Changes/\ubcc0\uacbd\uc0ac\ud56d) \uc139\uc158\uc744 \ucd94\uac00\ud574\uc8fc\uc138\uc694.\n\n> Automated by jclee-bot');
             }
 
   check-large-files:
@@ -118,7 +138,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect large file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -154,7 +174,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect sensitive file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({


### PR DESCRIPTION
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.
