### PR TITLE
chore(ci): remove auto-merge check_suite noise + harden release commit step

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,8 +5,10 @@ on:
     types: [opened, synchronize, ready_for_review, reopened, labeled]
   pull_request_review:
     types: [submitted]
-  check_suite:
-    types: [completed]
+  # Note: `check_suite` is intentionally NOT a trigger here. It fires on every
+  # check-suite completion (including those on master where no PR exists), and the
+  # downstream reusable workflow has nothing to merge in that case — producing
+  # spurious failure runs that pollute the Actions tab.
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,15 @@ jobs:
       - name: Commit version bump
         if: steps.bump.outputs.should_release == 'true' && github.event.inputs.dry_run != 'true'
         run: |
+          set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json CHANGELOG.md
-          git commit -m "chore(release): ${{ steps.bump.outputs.new_tag }} [skip ci]" || echo 'No changes to commit'
+          if git diff --staged --quiet; then
+            echo 'Nothing to commit — package.json and CHANGELOG.md unchanged'
+            exit 0
+          fi
+          git commit -m "chore(release): ${{ steps.bump.outputs.new_tag }} [skip ci]"
           git push origin master
 
       - name: Create tag and GitHub Release


### PR DESCRIPTION
Two pre-existing CI noise sources flagged during E2E debug session, neither blocking but both polluting the Actions tab.

## 1. auto-merge.yml — Remove \`check_suite\` trigger

\`check_suite: completed\` fires on **every** check-suite completion, including ones on master where no PR exists. The downstream reusable workflow (\`jclee941/.github/.github/workflows/_auto-merge.yml@master\`) then fails because there is no PR to merge. Recent runs:

| Run | Branch | Event | Conclusion |
|---|---|---|---|
| 25298923764 | master | check_suite | failure (no PR to merge) |
| 25298926620 | feature branch | pull_request_target | success |
| 25299010001 | master | check_suite | failure (no PR to merge) |

Removed the \`check_suite\` trigger and added an inline comment documenting why. \`pull_request_target\` and \`pull_request_review\` triggers cover the actual auto-merge use case.

## 2. release.yml — Harden \"Commit version bump\"

The original step:
\`\`\`yaml
git commit -m \"...\" || echo 'No changes to commit'
git push origin master
\`\`\`

was fragile when used with implicit shell flags. Replaced with an explicit guard:
\`\`\`yaml
set -euo pipefail
git add package.json CHANGELOG.md
if git diff --staged --quiet; then
  echo 'Nothing to commit'
  exit 0
fi
git commit -m \"...\"
git push origin master
\`\`\`

This makes the no-op case (when no commits since last tag would change \`package.json\` / \`CHANGELOG.md\`) exit 0 cleanly, instead of surfacing as a step failure.

## Verification

- ✅ \`npm run lint\` — 0 errors
- ✅ \`npm run typecheck\` — pass
- ✅ \`actionlint .github/workflows/auto-merge.yml release.yml\` — 0 errors
- ✅ \`npm test\` — 4 pass / 0 fail

## Out of scope

- Cloudflare \`Workers Builds: resume\` infrastructure failure remains; manual \`npx wrangler deploy\` workaround documented in \`.sisyphus/evidence/workers-builds-infra.md\`. Requires Cloudflare dashboard / API token investigation outside the repo.