### PR TITLE
fix(seo): JSON-LD Person.description passive ending sync with SSoT

### DIFF
--- a/apps/portfolio/index.html
+++ b/apps/portfolio/index.html
@@ -73,7 +73,7 @@
         "name": "이재철",
         "alternateName": "Jaecheol Lee",
         "jobTitle": "DevSecOps/SRE/Platform Engineer",
-        "description": "금융권 보안 규제 환경에서 인프라 설계·운용을 담당하며, 본인가 심사 대응을 통과한 경험이 있습니다. 분산된 보안 장비와 수동 운영의 비효율을 통합 자동화로 개선하고, 실시간 탐지와 자동 대응 체계를 구축한 경험이 있습니다.",
+        "description": "폐쇄망 OA 운영실에서 출발해 금융 거래소 보안 운영으로 도착한 8년차 DevSecOps/SRE 엔지니어. \"반복 작업은 자동화 되어야 한다\"는 신념으로 FortiGate HA 망분리 위에서 Splunk ES + n8n + FortiManager API로 보안 이벤트 자동 탐지·대응을 운영합니다.",
         "url": "https://resume.jclee.me",
         "email": "qws941@kakao.com",
         "telephone": "+82-10-5757-9592",


### PR DESCRIPTION
Hotfix discovered after PR #122 deploy. The JSON-LD Person schema embedded in `apps/portfolio/index.html` was still serving the old text containing "경험이 있습니다" (×2) for KO root path.

Per `apps/portfolio/AGENTS.md` content-update pattern, JSON-LD `Person.description` must match the SSoT `personal.profileStatement`. Synced.

Production verification: SSoT had 0 passive endings, but `https://resume.jclee.me/` HTML had 1 hit on `경험이 있습니다`. After this PR, sweep on rebuilt worker.js: 0 hits.

Verification:
- ✅ `npm run build` — worker.js regenerates
- ✅ Active sources sweep: 0 hits for `경험이 있습니다`, `활용하고 있습니다`