### PR TITLE
fix(seo): align JSON-LD Person.description across KO/EN/JA

### DIFF
--- a/apps/portfolio/index-en.html
+++ b/apps/portfolio/index-en.html
@@ -73,7 +73,7 @@
         "name": "이재철",
         "alternateName": "Jaecheol Lee",
         "jobTitle": "DevSecOps/SRE/Platform Engineer",
-        "description": "DevSecOps/SRE engineer who designed and operated security infrastructure in financial regulated environments and passed regulatory licensing audits. Built integrated automation, real-time detection, and automated response systems to address the inefficiencies of fragmented security appliances and manual operations.",
+        "description": "8-year DevSecOps/SRE engineer who started from closed-network OA operations and arrived at financial-exchange security operations. Driven by the belief that 'repetitive work should be automated', operates automated security-event detection and response on FortiGate HA network segmentation with Splunk ES + n8n + FortiManager API.",
         "url": "https://resume.jclee.me",
         "email": "qws941@kakao.com",
         "telephone": "+82-10-5757-9592",

--- a/apps/portfolio/lib/html-transformer.js
+++ b/apps/portfolio/lib/html-transformer.js
@@ -83,7 +83,7 @@ function buildJapaneseTemplate(html) {
     // === JA JSON-LD description ===
     .replace(/"description": "금융권 보안 규제 환경에서 인프라 설계·운용을 담당하며[^"]*"/g, '"description": "金融規制環境でインフラ設計・運用を担当し、FSC本認可対応を通過したOAエンジニア出身、8年目のDevSecOps/SREエンジニアです。分散したセキュリティ機器と手動運用の非効率を統合自動化で改善し、リアルタイム検知と自動対応体制を構築した経験があります。"')
     .replace(/"description": "금융권 규제 환경에서 보안 인프라 설계·운영을 담당한[^"]*"/g, '"description": "金融規制環境でセキュリティインフラ設計·運用を担当したDevSecOps/SRE/Platform Engineerの個人ポートフォリオ。"')
-    .replace(/"description": "폐쇄망 OA 운영실에서 출발해(?:\\.|[^"\\])*"/g, '"description": "閉鎖網OA運用室から出発し、金融取引所セキュリティ運用に到達した8年目のDevSecOps/SREエンジニア。「繰り返し作業は自動化されるべき」という信念でFortiGate HA·ネットワーク分離を上にSplunk ES + n8n + FortiManager APIでセキュリティイベントを自動検知・対応しています。"')
+    .replace(/"description": "폐쇄망 OA 운영실에서 출발해(?:\\.|[^"\\])*"/g, '"description": "閉鎖網OA運用室から出発し、金融取引所セキュリティ運用に到達した8年目のDevSecOps/SREエンジニア。「繰り返し作業は自動化されるべき」という信念でFortiGate HAネットワーク分離の上でSplunk ES + n8n + FortiManager APIによるセキュリティイベントの自動検知・対応を運用しています。"')
     // === JA hero copy (replace KO hero text with Japanese) ===
     .replace(/<span class="typing-effect glow-cyan">이재철<\/span/g, '<span class="typing-effect glow-cyan">イ・ジェチョル</span')
     .replace(/<span class="sr-only">이재철<\/span>/g, '<span class="sr-only">イ・ジェチョル</span>')


### PR DESCRIPTION
Oracle 3rd-pass blocker: live KO/EN/JA Person.description didn't describe the same person.

| Lang | Before | After |
|------|--------|-------|
| KO (166) | unchanged | unchanged |
| EN (316→330) | 'designed and operated security infrastructure in financial regulated environments...regulatory licensing audits...integrated automation' (different broader narrative) | '8-year DevSecOps/SRE engineer who started from closed-network OA operations and arrived at financial-exchange security operations. Driven by the belief that repetitive work should be automated, operates automated security-event detection and response on FortiGate HA network segmentation with Splunk ES + n8n + FortiManager API.' |
| JA (161→165) | passive '対応しています' | active '運用しています' (mirrors KO '운영합니다') |

All 3 locales now share the same trajectory + same tech stack + same belief, in their respective language.

Verification (live):
- KO/EN/JA Person.description all reference: closed-network OA → financial exchange, 'repetitive work should be automated' belief, FortiGate HA, Splunk ES, n8n, FortiManager API
- JSON-LD parse tests on /, /en/, /ja/ all pass
- npm run lint / typecheck / build all pass