### PR TITLE
fix(seo): redirect / to /en/ or /ja/ on Accept-Language for canonical stability

### DIFF
--- a/apps/portfolio/entry.js
+++ b/apps/portfolio/entry.js
@@ -93,27 +93,48 @@ export default {
       } else if (url.pathname.startsWith(JOB_ROUTE_PREFIX)) {
         response = await fetchJobHandlerResponse(request, env, ctx, url.pathname);
       } else if (LOCALE_ROUTES.has(url.pathname)) {
-        const targetPath = getPortfolioTargetPath(url.pathname, languageContext.language);
-        const targetUrl = new URL(request.url);
-        targetUrl.pathname = targetPath;
+        // SEO: when '/' is hit purely because of Accept-Language negotiation,
+        // redirect non-Korean clients to /en/ or /ja/ so canonical URLs stay stable.
+        if (
+          url.pathname === '/' &&
+          languageContext.source === 'accept-language' &&
+          languageContext.language &&
+          languageContext.language !== DEFAULT_LANGUAGE
+        ) {
+          const localePathname = languageContext.language === 'en' ? '/en/' : '/ja/';
+          const redirectUrl = new URL(request.url);
+          redirectUrl.pathname = localePathname;
+          response = new Response(null, {
+            status: 302,
+            headers: {
+              Location: redirectUrl.toString(),
+              Vary: 'Accept-Language',
+              'Cache-Control': 'no-cache',
+            },
+          });
+        } else {
+          const targetPath = getPortfolioTargetPath(url.pathname, languageContext.language);
+          const targetUrl = new URL(request.url);
+          targetUrl.pathname = targetPath;
 
-        const localizedRequest = new Request(targetUrl.toString(), request);
-        localizedRequest.headers.set('X-Detected-Language', languageContext.language);
-        localizedRequest.headers.set('X-Language-Source', languageContext.source);
+          const localizedRequest = new Request(targetUrl.toString(), request);
+          localizedRequest.headers.set('X-Detected-Language', languageContext.language);
+          localizedRequest.headers.set('X-Language-Source', languageContext.source);
 
-        let portfolioResponse = await portfolioWorker.fetch(localizedRequest, env, ctx);
-        if (isHtmlResponse(portfolioResponse)) {
-          portfolioResponse = await localizeHtmlResponse(
-            portfolioResponse,
-            languageContext.language
-          );
+          let portfolioResponse = await portfolioWorker.fetch(localizedRequest, env, ctx);
+          if (isHtmlResponse(portfolioResponse)) {
+            portfolioResponse = await localizeHtmlResponse(
+              portfolioResponse,
+              languageContext.language
+            );
+          }
+
+          response = applyResponseHeaders(portfolioResponse, url.pathname, {
+            language: languageContext.language,
+            source: languageContext.source,
+            varyAcceptLanguage: false,
+          });
         }
-
-        response = applyResponseHeaders(portfolioResponse, url.pathname, {
-          language: languageContext.language,
-          source: languageContext.source,
-          varyAcceptLanguage: url.pathname === '/' && languageContext.source === 'accept-language',
-        });
       } else {
         const portfolioResponse = await portfolioWorker.fetch(request, env, ctx);
         response = applyResponseHeaders(portfolioResponse, url.pathname, {

--- a/apps/portfolio/lib/html-transformer.js
+++ b/apps/portfolio/lib/html-transformer.js
@@ -69,6 +69,7 @@ function buildJapaneseTemplate(html) {
     .replace(/<meta property="og:url" content="https:\/\/resume\.jclee\.me" \/>/i, '<meta property="og:url" content="https://resume.jclee.me/ja/" />')
     .replace(/<meta property="og:title" content="[^"]*" \/>/i, '<meta property="og:title" content="イ・ジェチョル - DevSecOps/SRE/Platform Engineer" />')
     .replace(/<meta property="og:locale" content="ko_KR" \/>/i, '<meta property="og:locale" content="ja_JP" />\n    <meta property="og:locale:alternate" content="ko_KR" />')
+    .replace(/\s*<meta property="og:locale:alternate" content="ja_JP" \/>/g, '')
     .replace(/<meta name="twitter:url" content="https:\/\/resume\.jclee\.me" \/>/i, '<meta name="twitter:url" content="https://resume.jclee.me/ja/" />')
     .replace(/<meta name="twitter:title" content="[^"]*" \/>/i, '<meta name="twitter:title" content="イ・ジェチョル - DevSecOps/SRE/Platform Engineer" />')
     .replace(/"name": "이재철 - DevSecOps\/SRE\/Platform Engineer"/g, '"name": "イ・ジェチョル - DevSecOps/SRE/Platform Engineer"')


### PR DESCRIPTION
Oracle 5th-pass blocker: `/` route returned different canonical URLs based on Accept-Language header.

| Header | Before (broken) | After (fixed) |
|---|---|---|
| (none) | 200, canonical `/` | 200, canonical `/` |
| en-US | 200, canonical `/en/` (mismatch with URL!) | 302 → `/en/` |
| ja-JP | 200, canonical `/ja/` (mismatch with URL!) | 302 → `/ja/` |

Plus: `/ja/` had self og:locale:alternate ja_JP — stripped during JA transform.

Verification (live):
- bare /: 200 OK, KO content, canonical=/  ✓
- / + Accept-Language: en-US: 302 → /en/  ✓
- / + Accept-Language: ja-JP: 302 → /ja/  ✓
- /ja/ og:locale:alternate: ko_KR, en_US (no self)  ✓