### PR TITLE
test(seo): canonical regression uses explicit locale per case

### DIFF
--- a/tests/e2e/seo.spec.js
+++ b/tests/e2e/seo.spec.js
@@ -273,16 +273,22 @@ test.describe('JSON-LD Structured Data', () => {
     expect(schemaCount).toBe(3);
   });
 
-  test('canonical URL matches route on each locale', async ({ page }) => {
+  test('canonical URL matches route on each locale', async ({ browser }) => {
     const cases = [
-      { path: '/', expected: 'https://resume.jclee.me/' },
-      { path: '/en/', expected: 'https://resume.jclee.me/en/' },
-      { path: '/ja/', expected: 'https://resume.jclee.me/ja/' },
+      { path: '/', locale: 'ko-KR', expected: 'https://resume.jclee.me/' },
+      { path: '/en/', locale: 'en-US', expected: 'https://resume.jclee.me/en/' },
+      { path: '/ja/', locale: 'ja-JP', expected: 'https://resume.jclee.me/ja/' },
     ];
-    for (const { path, expected } of cases) {
+    for (const { path, locale, expected } of cases) {
+      const ctx = await browser.newContext({
+        locale,
+        extraHTTPHeaders: { 'Accept-Language': `${locale},${locale.split('-')[0]};q=0.9` },
+      });
+      const page = await ctx.newPage();
       await page.goto(path, { waitUntil: 'domcontentloaded' });
       const canonical = await page.locator('link[rel="canonical"]').first().getAttribute('href');
       expect(canonical, `canonical for ${path}`).toBe(expected);
+      await ctx.close();
     }
   });
 


### PR DESCRIPTION
Follow-up to PR #138 redirect logic. Playwright's default browser sends Accept-Language: en-US which triggers the new / → /en/ redirect, making the canonical regression test fail because final URL becomes /en/ not /.

Fix: each test case creates a fresh browser context with explicit locale + Accept-Language matching the route's expected canonical.

Verified: 1 passed (5.5s).