### PR TITLE
fix(content): strip 'proactively' EN buzzword + visible-body rejected-pattern regression test

### DIFF
--- a/packages/data/resumes/master/resume_data_en.json
+++ b/packages/data/resumes/master/resume_data_en.json
@@ -261,7 +261,7 @@
       "teamSize": "On-site IT operations team (size undisclosed)",
       "myRole": "Closed-network server operations and security patching engineer",
       "workType": "Full-time (Dispatched)",
-      "description": "Established a routine log analysis cadence and adhered to security audit guidelines to proactively detect hardware failure indicators in a closed network environment.",
+      "description": "Established a routine log analysis cadence and adhered to security audit guidelines to identify hardware failure indicators early in a closed network environment.",
       "note": "MTData employee, dispatched to Korea Aerospace Industries (KAI) IT infrastructure field operations",
       "projects": [
         {

--- a/tests/e2e/seo.spec.js
+++ b/tests/e2e/seo.spec.js
@@ -273,6 +273,19 @@ test.describe('JSON-LD Structured Data', () => {
     expect(schemaCount).toBe(3);
   });
 
+  test('rejected buzzwords/metrics absent on all locales', async ({ page }) => {
+    const REJECTED = ['proactively', 'proactive', 'SOC 24/7', '150대', '1,000명',
+      '1,000-user', 'MTTR 30→12', '5분→30초', 'Polyglot', 'AIOps',
+      '활용하고 있습니다', '경험이 있습니다'];
+    const routes = ['/', '/en/', '/ja/'];
+    for (const r of routes) {
+      await page.goto(r, { waitUntil: 'domcontentloaded' });
+      const bodyText = await page.evaluate(() => document.body.innerText);
+      const hits = REJECTED.filter((p) => bodyText.includes(p));
+      expect(hits, `route ${r} contains rejected: ${hits.join(',')}`).toEqual([]);
+    }
+  });
+
   test('canonical URL matches route on each locale', async ({ browser }) => {
     const cases = [
       { path: '/', locale: 'ko-KR', expected: 'https://resume.jclee.me/' },

--- a/tools/scripts/utils/resume-web-data-generator.js
+++ b/tools/scripts/utils/resume-web-data-generator.js
@@ -38,7 +38,7 @@ function generateWebData(source) {
     '(주)엠티데이타': {
       title: 'MT Data Co., Ltd.',
       description:
-        'Established a routine log analysis cadence and adhered to security audit guidelines to proactively detect hardware failure indicators in a closed network environment.',
+        'Established a routine log analysis cadence and adhered to security audit guidelines to identify hardware failure indicators early in a closed network environment.',
     },
   };
 


### PR DESCRIPTION
Oracle 6th-pass blocker: 'proactively detect hardware failure indicators' surviving on /en/ in MT Data career description.

Replaced with 'identify hardware failure indicators early' across SSoT, generator, and regenerated data.json artifacts.

Plus new regression test scans visible body text on all 3 locales for 12 rejected patterns. Verified locally: 1 passed.

Live verification (post-deploy 3a19274d):
- /, /en/, /ja/: proactively count = 0