### PR TITLE
fix(css): status-seeking line wraps on mobile (was overflowing /en/ at 390px)

### DIFF
--- a/apps/portfolio/src/styles/hero.css
+++ b/apps/portfolio/src/styles/hero.css
@@ -121,7 +121,17 @@
     margin-left: 0;
     width: 100%;
     justify-content: flex-start;
+    flex-wrap: wrap;
+    row-gap: var(--space-1);
+    font-size: var(--text-xs);
+    padding: var(--space-2) var(--space-3);
   }
+  .status-seeking__cta {
+    word-break: break-all;
+    min-width: 0;
+  }
+  .status-seeking__divider {
+    display: none;
 }
 
 /* Hero positioning + KPI grid (added per recruiter audit) */


### PR DESCRIPTION
Oracle 7th-pass found mobile CTA overflow on /en/ at viewport 390x844: `.status-seeking__cta` extended ~76px past viewport.

Fix: @media (max-width: 640px) rule for .status-seeking now flex-wrap + smaller font + email word-break + hide divider.

Verified live (post-deploy e73487d6) on /, /en/, /ja/: all overflow=false at 390x844.