### PR TITLE
fix(css): close @media block in hero.css (PR #141 brace regression)

### DIFF
--- a/apps/portfolio/src/styles/hero.css
+++ b/apps/portfolio/src/styles/hero.css
@@ -132,6 +132,7 @@
   }
   .status-seeking__divider {
     display: none;
+  }
 }
 
 /* Hero positioning + KPI grid (added per recruiter audit) */


### PR DESCRIPTION
Master patch. PR #141 left hero.css with brace balance=1 because .status-seeking__divider was missing closing }. Fixed; brace balance now 0. Tested at 4 viewports: tablet 768 grid_cols correctly = '345px 345px' (was 'block').