### PR TITLE
fix(seo): derive sitemap ETag/Last-Modified from BUILD_LASTMOD (was frozen)

### DIFF
--- a/apps/portfolio/lib/entry-router-utils.js
+++ b/apps/portfolio/lib/entry-router-utils.js
@@ -1,6 +1,10 @@
 const BUILD_LASTMOD = '2026-05-04';
-const BUILD_LASTMOD_HTTP = 'Tue, 28 Apr 2026 00:00:00 GMT';
-const BUILD_ETAG_VERSION = '20260428';
+// Derive HTTP-format Last-Modified and ETag from BUILD_LASTMOD so they cannot drift.
+const BUILD_LASTMOD_HTTP = (() => {
+  const d = new Date(`${BUILD_LASTMOD}T00:00:00Z`);
+  return d.toUTCString();
+})();
+const BUILD_ETAG_VERSION = BUILD_LASTMOD.replace(/-/g, '');
 const LAST_MODIFIED = BUILD_LASTMOD_HTTP;
 const SITEMAP_LASTMOD = BUILD_LASTMOD;
 const SITEMAP_ETAG = `W/"resume-sitemap-${BUILD_ETAG_VERSION}"`;


### PR DESCRIPTION
Oracle 9th-pass blocker. Sitemap body fresh but ETag/Last-Modified frozen at 20260428.

Fixed by computing both from BUILD_LASTMOD constant. Verified live: ETag now '20260504', Last-Modified now 2026-05-04, stale-ETag conditional returns 200 not 304.