### PR TITLE
ci(docs-sync): exclude applications/ from markdown-lint

### DIFF
--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -66,7 +66,8 @@ jobs:
             --ignore node_modules \
             --ignore '**/node_modules/**' \
             --ignore .venv \
-            --ignore '**/pr-agent-upstream-README.md'
+            --ignore '**/pr-agent-upstream-README.md' \
+            --ignore 'applications/**'
 
   readme-sync-check:
     runs-on: ubuntu-latest

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,5 @@
+node_modules/
+.git/
+.opencode/
+.sisyphus/
+applications/


### PR DESCRIPTION
Application materials use longer lines for readability and don't need MD013/MD029. Add ignore pattern to reusable-docs-sync workflow + .markdownlintignore.