### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -56,15 +56,22 @@ jobs:
         run: |
           rm -rf /tmp/gitleaks.tmp /tmp/gitleaks-8.24.3
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      - name: Install gitleaks
+        run: |
+          wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
+      - name: Run gitleaks detect
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            echo "Scanning PR commits: ${BASE_SHA}^..${HEAD_SHA}"
+            gitleaks detect --source . --log-opts "${BASE_SHA}^..${HEAD_SHA}" --redact --verbose --exit-code 1
+          else
+            echo "Scanning full repository"
+            gitleaks detect --source . --redact --verbose --exit-code 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # GITLEAKS_LICENSE only required for organization-scope scanning.
-          GITLEAKS_NOTIFY_USER_LIST: '@jclee941'
-          GITLEAKS_ENABLE_COMMENTS: 'true'
-          GITLEAKS_ENABLE_SUMMARY: 'true'
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: 'false'
-          # GITLEAKS_CONFIG intentionally unset - gitleaks CLI auto-detects
-          # repo-local .gitleaks.toml. Setting it to a non-existent path
-          # would hard-fail the action across all downstream repos.


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- gitleaks GitHub Action 제거 및 CLI 전환

- PR 커밋 범위 선택적 스캔 지원

- Action 전용 환경 변수 정리


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gitleaks-action@v2"] --> B["wget CLI v8.30.1"]
  B --> C{"PR 이벤트?"}
  C -- "예" --> D["base..head 스캔"]
  C -- "아니오" --> E["전체 저장소 스캔"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitleaks.yml</strong><dd><code>gitleaks 워크플로우 CLI 전환 및 PR 범위 스캔</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gitleaks.yml

<ul><li><code>gitleaks/gitleaks-action@v2</code> 제거 및 <code>gitleaks</code> CLI v8.30.1 수동 설치<br> <li> <code>pull_request</code> 이벤트 시 <code>github.event.pull_request.base.sha</code>에서 <code>head.sha</code>까지 커밋 <br>범위만 스캔<br> <li> 기타 이벤트 발생 시 전체 저장소를 스캔하도록 조건부 실행 분기 추가<br> <li> <code>GITLEAKS_NOTIFY_USER_LIST</code>, <code>GITLEAKS_ENABLE_COMMENTS</code> 등 Action 전용 환경변수 <br>제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/214/files#diff-2aa7a05eafb406b4c582ed3bd35f2ef3a6fadeaad31372f62a79bd7610e1e453">+17/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

