### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    runs-on: self-hosted
+    runs-on: ${{ github.event.repository.private && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create issue for broken links
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = `## 🚨 문서 링크 깨짐 감지\n\n` +
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check README sync
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check API documentation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Auto-label new issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -89,7 +89,7 @@ jobs:
     if: github.event_name == 'issue_comment' || (github.event_name == 'issues' && contains(fromJson('["reopened", "edited"]'), github.event.action))
     steps:
       - name: Remove stale label on activity
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue || context.payload.comment?.issue;
@@ -112,7 +112,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Generate Issue Statistics
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -54,7 +54,7 @@ jobs:
     name: Check PR Title
     steps:
       - name: Conventional Commits validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -80,7 +80,7 @@ jobs:
     name: Check Branch Name
     steps:
       - name: Branch naming validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -106,7 +106,7 @@ jobs:
     name: Check PR Description
     steps:
       - name: Description validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect large file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -191,7 +191,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect sensitive file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Dependabot 워크플로우에 공개/비공개 저장소 조건부 러너 적용

- 재사용 워크플로우 `actions/github-script` `v9`에서 `v7`로 다운그레이드

- 문서·이슈·PR 검증 작업의 액션 버전 일관성 확보


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot 워크플로우"] --> B{"저장소 공개 여부"}
  B -- "비공개" --> C["self-hosted"]
  B -- "공개" --> D["ubuntu-latest"]
  E["재사용 워크플로우"] --> F["github-script v7"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml`</strong><dd><code>Dependabot 워크플로우 러너 조건화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/dependabot-auto-merge.yml`

<ul><li><code>runs-on</code>을 고정된 <code>self-hosted</code>에서 조건부 표현식으로 변경<br> <li> 비공개 저장소는 <code>self-hosted</code>, 공개 저장소는 <code>ubuntu-latest</code> 사용</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-docs-sync.yml`</strong><dd><code>문서 동기화 워크플로우 github-script v7 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/reusable-docs-sync.yml`

<ul><li><code>actions/github-script</code> 액션 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> 깨진 링크 이슈 생성, README 동기화, API 문서 검증 단계에 일괄 적용</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-issue-management.yml`</strong><dd><code>이슈 관리 워크플로우 github-script v7 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/reusable-issue-management.yml`

<ul><li><code>actions/github-script</code> 액션 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> 자동 라벨링, stale 제거, 이슈 통계 생성 단계에 일괄 적용</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml`</strong><dd><code>PR 검증 워크플로우 github-script v7 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/reusable-pr-checks.yml`

<ul><li><code>actions/github-script</code> 액션 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> PR 제목, 브랜치명, 설명, 대용량 파일, 민감 파일 검증 단계에 적용</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

