### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -58,7 +58,10 @@ jobs:
           for REPO in $REPOS; do
             FULL="jclee941/$REPO"
             for WF in "${WORKFLOWS[@]}"; do
-              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]')
+              # Tolerate repos/workflows that don't exist: gh exits non-zero
+              # ("could not find any workflows named ...") which would abort the
+              # step under bash -e. Fall back to empty and skip via the check below.
+              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]' 2>/dev/null || true)
               if [ -z "$LATEST" ] || [ "$LATEST" = "[]" ]; then
                 continue
               fi


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- 하위 저장소 워크플로우 부재 시 스크립트 중단 방지

- `gh run list` 실패 시 빈 값으로 폴백 처리

- `bash -e` 환경에서도 누락된 워크플로우를 자동으로 무시


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gh run list 실행"] --> B{"워크플로우 존재?"}
  B -- "성공" --> C["결과 파싱"]
  B -- "없음/오류" --> D["2>/dev/null \|\| true"]
  D --> E["빈 값 반환 및 skip"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>하위 저장소 헬스 체크 오류 허용 로직 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li><code>gh run list</code> 명령이 실패할 경우 <code>bash -e</code>로 인한 스크립트 중단을 방지<br> <li> 표준 에러를 <code>/dev/null</code>로 리다이렉트하고 <code>|| true</code>로 빈 문자열을 반환하도록 수정<br> <li> 존재하지 않는 하위 저장소나 워크플로우에 대해 루프가 자동으로 건너뛰어짐</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/371/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

