### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/12_dependabot-auto-merge.yml
+++ b/.github/workflows/12_dependabot-auto-merge.yml
@@ -141,9 +141,24 @@ jobs:
           if [[ "$state" == "BLOCKED" && "$failed" == "0" ]]; then
             echo "::notice::PR $PR_URL is BLOCKED with no failing checks; updating branch to clear stale required-context drift"
             # gh CLI on the runner may predate the `gh pr update-branch`
-            # subcommand, so call the REST endpoint directly.
-            gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
-              || echo "::warning::update-branch failed (already up to date, conflict, or not permitted); not retrying"
+            # subcommand, so call the REST endpoint directly. Capture the
+            # response so genuine failures (auth, 5xx) surface instead of
+            # being swallowed; only HTTP 422 (branch already up to date or an
+            # un-updatable merge conflict) is a benign, expected outcome.
+            # subcommand, so call the REST endpoint directly. Capture the
+            # response so genuine failures (auth, 5xx) surface instead of
+            # being swallowed; only HTTP 422 (branch already up to date or an
+            # un-updatable merge conflict) is a benign, expected outcome.
+            if gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
+              >/tmp/update_branch_out 2>/tmp/update_branch_err; then
+              echo "::notice::update-branch succeeded for $PR_URL"
+            elif grep -qE 'HTTP 422|already up to date|merge conflict' /tmp/update_branch_err; then
+              echo "::notice::update-branch not needed for $PR_URL (already up to date or unmergeable conflict)"
+            else
+              echo "::error::update-branch failed for $PR_URL"
+              cat /tmp/update_branch_err >&2 || true
+              exit 1
+            fi
           else
             echo "::notice::PR $PR_URL mergeStateStatus=$state failed=$failed; no self-heal needed"
           fi


### PR DESCRIPTION
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.
