### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/19_issue-backfill.yml
+++ b/.github/workflows/19_issue-backfill.yml
@@ -17,10 +17,11 @@ name: Issue Backfill
 # actually mutates labels.
 
 on:
-  issues:
-    types: [opened, edited, reopened, labeled, unlabeled]
+  # NOTE: not triggered by `issues:` nor by Issue Management/Classification —
+  # 19 ADDS the in-progress label, which would re-fire those issue workflows
+  # and loop. Driven by a master-activity pulse (Sanity) + manual dispatch.
   workflow_run:
-    workflows: ["Issue Management", "Issue Classification"]
+    workflows: ["Sanity"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -70,7 +71,10 @@ jobs:
           # the backfill silently completes without triggering branch
           # creation.
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run == false && 'false' || 'true' }}
+          # Mutate ONLY on an explicit manual dispatch with dry_run=false.
+          # Any event-driven (workflow_run) run is always dry-run so it can
+          # never add labels (which would re-trigger issue workflows / loop).
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && 'false' || 'true' }}
           MIN_AGE_DAYS: ${{ inputs.min_age_days || '5' }}
           MAX_PICKS: ${{ inputs.max_picks || '3' }}
           LABEL: ${{ inputs.label || 'in-progress' }}
@@ -81,9 +85,14 @@ jobs:
           THRESHOLD=$((NOW - MIN_AGE_DAYS * 86400))
           SKIP_LABELS="wontfix duplicate invalid bot-review ci-failure automated dependencies"
           # Pre-fetch open issues; up to 100 per page is fine for our repos.
-          gh issue list --repo "$REPO" --state open --limit 100 \
+          # Tolerate transient API failures (rate limit, 5xx): warn and skip this
+          # run rather than failing the workflow (event-driven runs are frequent).
+          if ! gh issue list --repo "$REPO" --state open --limit 100 \
             --json number,title,updatedAt,labels,assignees \
-            > /tmp/issues.json
+            > /tmp/issues.json 2>/tmp/issues.err; then
+            echo "::warning::issue-backfill: gh issue list failed for $REPO (likely transient/rate-limit); skipping this run. $(cat /tmp/issues.err)"
+            exit 0
+          fi
           PICKED=0
           {
             echo "## Issue Backfill Candidates ($REPO)"

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -50,8 +50,8 @@ concurrency:
 
 jobs:
   triage:
-    # The event-driven path handles workflow_run + manual dispatch. The daily
-    # schedule is handled by the separate `sweep` job below.
+    # Event-driven triage: fires only on workflow_run of a watched workflow.
+    # The stale-issue sweep (manual/repository_dispatch/recovery) is the `sweep` job below.
     if: github.event_name == 'workflow_run'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
@@ -66,11 +66,6 @@ jobs:
         id: ev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_WORKFLOW_NAME: ''
-          INPUT_HEAD_SHA: ''
-          INPUT_RUN_ID: ''
-          INPUT_CONCLUSION: ''
-          INPUT_PR_NUMBER: '0'
           EVENT_NAME: ${{ github.event_name }}
           WF_RUN_NAME: ${{ github.event.workflow_run.name }}
           WF_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -79,19 +74,13 @@ jobs:
           WF_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '0' }}
         run: |
           set -eu
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            WF_NAME="$INPUT_WORKFLOW_NAME"
-            HEAD_SHA="$INPUT_HEAD_SHA"
-            RUN_ID="$INPUT_RUN_ID"
-            CONCLUSION="$INPUT_CONCLUSION"
-            PR_NUMBER="$INPUT_PR_NUMBER"
-          else
-            WF_NAME="$WF_RUN_NAME"
-            HEAD_SHA="$WF_RUN_HEAD_SHA"
-            RUN_ID="$WF_RUN_ID"
-            CONCLUSION="$WF_RUN_CONCLUSION"
-            PR_NUMBER="$WF_RUN_PR_NUMBER"
-          fi
+          # triage runs only on workflow_run (job `if:` above), so the event
+          # fields always come from github.event.workflow_run.
+          WF_NAME="$WF_RUN_NAME"
+          HEAD_SHA="$WF_RUN_HEAD_SHA"
+          RUN_ID="$WF_RUN_ID"
+          CONCLUSION="$WF_RUN_CONCLUSION"
+          PR_NUMBER="$WF_RUN_PR_NUMBER"
 
           # Validate inputs
           if ! [[ "$HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -162,7 +151,7 @@ jobs:
           set -euo pipefail
           # Map the recovered workflow NAME -> title substrings of the stable
           # (and legacy) failure/health issues it creates. On success, close
-          # them immediately (event-driven), complementing the daily sweep.
+          # them immediately (event-driven), complementing the manual/recovery sweep.
           case "$WF_NAME" in
             "Gitleaks") SUBS='Gitleaks Scan Failed' ;;
             "CodeQL") SUBS='CodeQL Analysis Failed' ;;
@@ -316,7 +305,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-on-failure
 
-  # Daily sweep: auto-close stale failure/health issues whose originating
+  # Stale-issue sweep (manual / repository_dispatch / on a watched workflow's
   # workflow has since recovered. Maps each open issue to its workflow file by
   # title pattern, queries that workflow's latest COMPLETED run on the default
   # branch, and closes the issue when the latest run conclusion is success.

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -1,7 +1,7 @@
 name: CI Auto-Heal
 on:
   workflow_run:
-    workflows: ["Sanity", "PR Checks", "Gitleaks", "CodeQL", "actionlint", "E2E Tests", "Downstream Health Check"]
+    workflows: ["Sanity", "PR Checks", "Gitleaks", "CodeQL", "actionlint", "E2E Tests", "Downstream Health Check", "Release Publish", "Scorecard supply-chain security"]
     types: [completed]
   check_suite:
     types: [completed]

--- a/.github/workflows/91_issue-classification.yml
+++ b/.github/workflows/91_issue-classification.yml
@@ -10,7 +10,7 @@ name: Issue Classification
 #   * resolved-from-signal      — on edits/comments carrying an explicit
 #                                 "fixed/resolved" signal, label `resolved`
 #                                 (close only when opted in).
-#   * resolved-sweep            — scheduled sweep: open issues whose linked PR is
+#   * resolved-sweep            — manual sweep (workflow_dispatch): open issues whose linked PR is
 #                                 already merged get labeled/closed.
 #
 # All pure logic lives in `.github/scripts/issue-classifier.cjs` (unit-tested via
@@ -78,7 +78,7 @@ env:
   DUPLICATE_CLOSE_THRESHOLD: ${{ inputs.duplicate_close_threshold || '0.86' }}
   CLOSE_DUPLICATES: ${{ inputs.close_duplicates || 'false' }}
   # Default ON. Only a workflow_dispatch run that explicitly sets the input to
-  # false may disable it; on issues/PR/schedule events `inputs` is absent and we
+  # false may disable it; on issues/PR events `inputs` is absent and we
   # must NOT let empty-string coerce to false.
   CLOSE_RESOLVED_BY_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.close_resolved_by_pr == false && 'false' || 'true' }}
   CLOSE_RESOLVED_BY_SIGNAL: ${{ inputs.close_resolved_by_signal || 'false' }}


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 백필 워크플로우 루프 제거 및 API 오류 대응

- CI 실패 트라이지 수동 실행 제거 및 단순화

- 자동 복구 범위에 릴리즈/보안 워크플로우 포함

- 이슈 분류 주석 및 드라이런 조건 문구 정정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue Backfill"] -- "Sanity workflow_run only" --> B["Prevent Label Loop"]
  C["CI Failure Triage"] -- "remove manual dispatch" --> D["workflow_run only"]
  E["CI Auto-Heal"] -- "add monitors" --> F["Release Publish & Scorecard"]
  G["gh issue list"] -- "transient failure" --> H["Warn and Skip"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>19_issue-backfill.yml</strong><dd><code>이슈 백필 트리거 및 드라이런 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/19_issue-backfill.yml

<ul><li><code>issues</code> 트리거와 <code>Issue Management</code>/<code>Issue Classification</code> <code>workflow_run</code> 트리거를 <br>제거하고, <code>Sanity</code> 워크플로우 완료 시에만 실행되도록 변경하여 <code>in-progress</code> 레이블 추가로 인한 순환 실행 방지<br> <li> <code>DRY_RUN</code> 값이 명시적인 <code>workflow_dispatch</code> 이벤트에서만 <code>false</code>가 되도록 강화하고, 이벤트 기반 실행은 <br>항상 건조 실행(dry-run)이 되어 의도치 않은 레이블 변경 방지<br> <li> <code>gh issue list</code> 명령 실행 중 일시적 API 장애(속도 제한, 5xx) 발생 시 워크플로우를 실패시키지 않고 경고 <br>출력 후 건너뛰도록 오류 처리 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/494/files#diff-914e840b0cc93b17a66743ce19039a60377cd51fd51d85800fdb6edf4072393d">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 트라이지 이벤트 소스 단순화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li><code>triage</code> 잡의 <code>workflow_dispatch</code> 실행 경로와 관련 입력 변수(<code>INPUT_*</code>)를 제거하여, <br><code>workflow_run</code> 이벤트에서만 실행되도록 단순화<br> <li> <code>workflow_run</code>이 아닌 경우의 조건부 분기 로직을 제거하고 이벤트 필드 참조를 직접 사용하도록 정리<br> <li> 주석 및 <code>sweep</code> 잡 설명을 <code>daily sweep</code>에서 <code>manual/recovery sweep</code>으로 수정하여 실제 트리거 <br>방식(<code>repository_dispatch</code>, 수동 실행)을 정확히 반영</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/494/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+11/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>CI 자동 복구 감시 워크플로우 확대</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li><code>workflow_run</code> 감시 대상 워크플로우 목록에 <code>Release Publish</code>와 <code>Scorecard supply-chain </code><br><code>security</code>를 추가하여 보안 및 릴리즈 파이프라인의 자동 복구 범위 확대</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/494/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>91_issue-classification.yml</strong><dd><code>이슈 분류 주석 및 트리거 설명 정정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/91_issue-classification.yml

<ul><li><code>resolved-sweep</code> 기능의 주석 설명을 <code>scheduled sweep</code>에서 <code>manual sweep </code><br><code>(workflow_dispatch)</code>으로 수정하여 실제 트리거 방식과 일치시킴<br> <li> <code>CLOSE_RESOLVED_BY_PR</code> 환경 변수 주석에서 스케줄 이벤트 관련 언급을 제거하여 코드 의도를 명확히 함</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/resume/pull/494/files#diff-925a942cf5a654079bece14ac3b1117622177ca4276c6bdc6cde64a0f9e34954">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

